### PR TITLE
Bugfix: Unexpected data in the item images payload crashing page

### DIFF
--- a/client/src/components/organisms/ImageGallery/ImageGallery.js
+++ b/client/src/components/organisms/ImageGallery/ImageGallery.js
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { ImagesWrapper, MiniImagesWrapper } from './ImageGallery.styles';
 
+const setImageSrc = (data) =>
+  data && data.url
+    ? data.url.replace('http://', 'https://')
+    : '/product-placeholder.jpeg';
+
 export const ImageGallery = ({ changeMainImage, mainImage, otherImages }) => {
   return (
     <ImagesWrapper>
@@ -11,18 +16,11 @@ export const ImageGallery = ({ changeMainImage, mainImage, otherImages }) => {
             onClick={changeMainImage}
             data-id={image._id}
             alt={`other images`}
-            src={image.url.replace('http://', 'https://')}
+            src={setImageSrc(image)}
           />
         ))}
       </MiniImagesWrapper>
-      <img
-        alt={`main`}
-        src={
-          mainImage && mainImage.url
-            ? mainImage.url.replace('http://', 'https://')
-            : '/product-placeholder.jpeg'
-        }
-      />
+      <img alt={`main`} src={setImageSrc(mainImage)} />
     </ImagesWrapper>
   );
 };


### PR DESCRIPTION
- addresses unexpected data in the item images causing 'access properties of undefined' error
- this applies the safe logic from the main image on the additional images
- still need to address the issue of bad data though


#### Error crashing page:
<img width="1340" alt="Screenshot 2023-08-04 at 23 09 16" src="https://github.com/Give-Your-Best/webshop/assets/22300973/760f035a-55bc-4004-b6b7-7f1ed3bd760c">

#### Bad data in the images payload:
<img width="567" alt="Screenshot 2023-08-04 at 23 12 39" src="https://github.com/Give-Your-Best/webshop/assets/22300973/15660007-600f-4696-a672-4f1962430579">
