### PR TITLE
Feature shopper address on item info popup

### DIFF
--- a/client/src/components/organisms/ImageGallery/ImageGallery.js
+++ b/client/src/components/organisms/ImageGallery/ImageGallery.js
@@ -1,10 +1,7 @@
 import * as React from 'react';
 import { ImagesWrapper, MiniImagesWrapper } from './ImageGallery.styles';
 
-const setImageSrc = (data) =>
-  data && data.url
-    ? data.url.replace('http://', 'https://')
-    : '/product-placeholder.jpeg';
+import { setImageSrc } from '../../../utils/helpers';
 
 export const ImageGallery = ({ changeMainImage, mainImage, otherImages }) => {
   return (

--- a/client/src/utils/helpers.js
+++ b/client/src/utils/helpers.js
@@ -241,7 +241,7 @@ export const checkPermission = (permissions, permission) => {
     .includes(permission.toLowerCase());
 };
 
-export const trunc = (str) => {
+export const trunc = (str = '') => {
   return str.length > 61 ? str.substring(0, 61) + '...' : str;
 };
 
@@ -311,12 +311,17 @@ export const checkUnread = (type, userId, messages) => {
   return [unread.length, unread];
 };
 
+export const setImageSrc = (data) =>
+  data && data.url
+    ? data.url.replace('http://', 'https://')
+    : '/product-placeholder.jpeg';
+
 export const getFrontImageUrl = (images) => {
   let imagesList = images.length ? images.filter((i) => i.front === true) : [];
   let image_url = imagesList.length
-    ? imagesList[0].url.replace('http://', 'https://')
+    ? setImageSrc(imagesList[0])
     : images.length
-    ? images[0].url.replace('http://', 'https://')
+    ? setImageSrc(images[0])
     : '';
 
   return image_url;

--- a/client/src/utils/helpers.js
+++ b/client/src/utils/helpers.js
@@ -114,6 +114,28 @@ export const getItemDetails = (item) => {
       '<br /></span>';
   }
 
+  //get shopper delivery address details
+  if (item.shopperId && item.shopperId.deliveryAddress) {
+    const { deliveryAddress } = item.shopperId;
+
+    detailsHtml += `<span><strong>Shopper Address:</strong>
+    <div>${(() => {
+      const { FAO, name, firstLine, secondLine, city, country, postcode } =
+        deliveryAddress;
+
+      const result =
+        (FAO ? `<span>FAO ${FAO}</span><br />` : '') +
+        (name ? `<span>${name}</span><br />` : '') +
+        (firstLine ? `<span>${firstLine}</span><br />` : '') +
+        (secondLine ? `<span>${secondLine}</span><br />` : '') +
+        (city ? `<span>${city}</span><br />` : '') +
+        (country ? `<span>${country}</span><br />` : '') +
+        (postcode ? `<span>${postcode}</span><br />` : '');
+
+      return result;
+    })()}</div>`;
+  }
+
   if (item.sendVia && item.sendVia.name) {
     locationName = item.sendVia.name;
     detailsHtml +=


### PR DESCRIPTION
Relates #37 

(A few unrelated updates on the utils helpers to get things running locally with missing dummy data etc.)

Adds address rendering on the item info popup where it is provided...

<img width="586" alt="Screenshot 2023-08-18 at 00 30 10" src="https://github.com/Give-Your-Best/webshop/assets/22300973/60444298-e684-4990-8eaf-e74f7f79afda">
