### PR TITLE
57 platform timeouts caused by long running queries

### DIFF
--- a/client/src/components/molecules/ItemsCollapsedList/ItemsCollapsedList.js
+++ b/client/src/components/molecules/ItemsCollapsedList/ItemsCollapsedList.js
@@ -167,18 +167,12 @@ export const ItemsCollapsedList = ({
     columns.push({
       title: 'Donor',
       dataIndex: 'donor',
-      render: (record) => {
-        return name(record);
-      },
-      ...getColumnSearchProps('donor'),
+      render: (text) => text,
     });
     columns.push({
       title: 'Shopper',
       dataIndex: 'shopper',
-      render: (record) => {
-        return name(record);
-      },
-      ...getColumnSearchProps('shopper'),
+      render: (text) => text,
     });
     columns.push({
       title: 'Tags',

--- a/client/src/components/organisms/Dashboard/AdminItems/AdminItems.js
+++ b/client/src/components/organisms/Dashboard/AdminItems/AdminItems.js
@@ -1,28 +1,23 @@
 import React, { useContext, useState, useEffect, useRef } from 'react';
-import { Modal } from 'antd';
+import { AutoComplete, Modal, Select, Space } from 'antd';
 import { AppContext } from '../../../../context/app-context';
 import { ItemCardLong, ItemsCollapsedList } from '../../../molecules';
-import {
-  StyledTab,
-  StyledTabList,
-  StyledTabs,
-  StyledTabPanel,
-} from './AdminItems.styles';
 import { getAdminItems, deleteItem } from '../../../../services/items';
 import { getTags } from '../../../../services/tags';
+import { getPublicUsers } from '../../../../services/user';
 import { tabList } from '../../../../utils/helpers';
 
 export const AdminItems = () => {
   const { token, user } = useContext(AppContext);
   const mountedRef = useRef(true);
   const [tags, setTags] = useState([]);
+  const [users, setUsers] = useState([]);
   const [items, setItems] = useState([]);
-  const [pastItems, setPastItems] = useState([]);
+  const [view, setView] = useState('current');
   const [totalItems, setTotalItems] = useState(0);
-  const [totalPastItems, setTotalPastItems] = useState(0);
   const [currentItemsPage, setCurrentItemsPage] = useState(1);
-  const [currentPastItemsPage, setCurrentPastItemsPage] = useState(1);
   // TODO - we need to look at the naming here it is getting confusing...
+  const [currentUser, setCurrentUser] = useState({});
 
   // Set this constant for now - we might want to allow adjustment later
   const limit = 10;
@@ -35,16 +30,17 @@ export const AdminItems = () => {
       className: 'modalStyle',
       onOk() {
         deleteItem(id, token).then(() => {
-          setItems(
-            items.filter((item) => {
-              return item._id !== id;
-            })
-          );
-          setPastItems(
-            pastItems.filter((item) => {
-              return item._id !== id;
-            })
-          );
+          // TODO need to update the component?
+          // setItems(
+          //   items.filter((item) => {
+          //     return item._id !== id;
+          //   })
+          // );
+          // setPastItems(
+          //   pastItems.filter((item) => {
+          //     return item._id !== id;
+          //   })
+          // );
         });
       },
     });
@@ -67,13 +63,27 @@ export const AdminItems = () => {
       }
     });
 
-    const fetchAllTags = async () => {
-      if (!mountedRef.current) return null;
+    const fetchTags = async () => {
       const tags = await getTags(token);
       setTags(tags);
     };
 
-    fetchAllTags();
+    const fetchUsers = async () => {
+      const data = await getPublicUsers(token);
+
+      setUsers(
+        data.map((d) => ({
+          label: `${d.firstName} ${d.lastName}`.trim(),
+          value: d._id,
+          type: d.kind,
+        }))
+      );
+    };
+
+    if (mountedRef.current) {
+      fetchTags();
+      fetchUsers();
+    }
 
     return () => {
       // cleanup
@@ -83,65 +93,121 @@ export const AdminItems = () => {
 
   useEffect(() => {
     const fetchItems = async () => {
-      const { total, items } = await getAdminItems(
-        true, // Current items
+      const { total, items } = await getAdminItems({
+        isCurrent: view === 'current', // Current items
         limit,
-        currentItemsPage
-      );
+        page: currentItemsPage,
+        donorId: currentUser.type === 'donor' ? currentUser.value : undefined,
+        shopperId:
+          currentUser.type === 'shopper' ? currentUser.value : undefined,
+      });
 
       setItems(items);
       setTotalItems(total);
     };
 
     fetchItems();
-  }, [token, user, currentItemsPage]);
+  }, [token, user, view, currentItemsPage, currentUser]);
 
-  useEffect(() => {
-    const fetchPastItems = async () => {
-      const { total, items } = await getAdminItems(
-        false, // Past items
-        limit,
-        currentPastItemsPage
-      );
+  const handleSelectUser = (_value, option) => {
+    setCurrentItemsPage(1);
+    setCurrentUser(option);
+  };
 
-      setPastItems(items);
-      setTotalPastItems(total);
-    };
+  const handleClearUser = () => {
+    setCurrentItemsPage(1);
+    setCurrentUser({});
+  };
 
-    fetchPastItems();
-  }, [token, user, currentPastItemsPage]);
+  const handleFilterOptions = (inputValue, option) => {
+    const re = new RegExp(inputValue, 'i');
+    return re.test(option.label);
+  };
+
+  const handleSelectView = (view) => {
+    setCurrentItemsPage(1);
+    setView(view);
+  };
+
+  const handleSetPage = (page) => setCurrentItemsPage(page);
 
   return (
-    <StyledTabs forceRenderTabPanel={true}>
-      <StyledTabList>
-        <StyledTab className="itemslist">Items</StyledTab>
-        <StyledTab>My Past Items</StyledTab>
-      </StyledTabList>
+    <>
+      <Space>
+        <Select
+          size="large"
+          style={{ width: 150 }}
+          placeholder="Items View"
+          defaultValue="current"
+          onSelect={handleSelectView}
+          options={[
+            {
+              label: 'Current Items',
+              value: 'current',
+            },
+            {
+              label: 'Past Items',
+              value: 'past',
+            },
+          ]}
+        />
 
-      <StyledTabPanel>
-        <ItemsCollapsedList
-          data={items}
-          total={totalItems}
-          current={currentItemsPage}
-          onChange={(page) => setCurrentItemsPage(page)}
-          expandRow={editForm}
-          handleDelete={handleDelete}
-          admin={true}
-          allTags={tags}
+        <AutoComplete
+          value={(currentUser || {}).label}
+          options={users}
+          style={{ width: 300 }}
+          size="large"
+          onClear={handleClearUser}
+          onSelect={handleSelectUser}
+          filterOption={handleFilterOptions}
+          placeholder="Shopper or Donor"
+          allowClear
         />
-      </StyledTabPanel>
-      <StyledTabPanel>
-        <ItemsCollapsedList
-          data={pastItems}
-          total={totalPastItems}
-          current={currentPastItemsPage}
-          onChange={(page) => setCurrentPastItemsPage(page)}
-          expandRow={editForm}
-          handleDelete={handleDelete}
-          admin={true}
-          allTags={tags}
-        />
-      </StyledTabPanel>
-    </StyledTabs>
+      </Space>
+
+      <ItemsCollapsedList
+        data={items}
+        total={totalItems}
+        current={currentItemsPage}
+        onChange={handleSetPage}
+        expandRow={editForm}
+        handleDelete={handleDelete}
+        admin={true}
+        allTags={tags}
+      />
+    </>
+    // <StyledTabs forceRenderTabPanel={true}>
+    //   <StyledTabList>
+    //     <StyledTab className="itemslist">Items</StyledTab>
+    //     <StyledTab>My Past Items</StyledTab>
+    //   </StyledTabList>
+
+    //   <StyledTabPanel>
+    //     <ItemsCollapsedList
+    //       data={items}
+    //       total={totalItems}
+    //       current={currentItemsPage}
+    //       onFilter={(...data) => console.log(...data)}
+    //       onChange={(page) => setCurrentItemsPage(page)}
+    //       expandRow={editForm}
+    //       handleDelete={handleDelete}
+    //       admin={true}
+    //       allTags={tags}
+    //     />
+    //   </StyledTabPanel>
+    //   <StyledTabPanel>
+    //     <ItemsCollapsedList
+    //       data={pastItems}
+    //       total={totalPastItems}
+    //       current={currentPastItemsPage}
+    //       onFilter={console.log}
+    //       onChange={(page) => setCurrentPastItemsPage(page)}
+    //       expandRow={editForm}
+    //       handleDelete={handleDelete}
+    //       admin={true}
+    //       allTags={tags}
+    //     />
+    //   </StyledTabPanel>
+    // </StyledTabs>
   );
 };

--- a/client/src/services/items/getAdminItems.js
+++ b/client/src/services/items/getAdminItems.js
@@ -5,18 +5,19 @@ export const getAdminItems = async ({
   donorId = undefined,
   shopperId = undefined,
 }) => {
-  const response = await fetch(
-    `/api/items/admin?isCurrent=${Boolean(
-      isCurrent
-    )}&limit=${limit}&page=${page}${donorId ? `&donorId=${donorId}` : ''}${
-      shopperId ? `&shopperId=${shopperId}` : ''
-    }`,
-    {
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    }
-  );
+  const params = new URLSearchParams({ isCurrent, limit, page });
+
+  if (donorId) {
+    params.set('donorId', donorId);
+  } else if (shopperId) {
+    params.set('shopperId', shopperId);
+  }
+
+  const response = await fetch(`/api/items/admin?${params.toString()}`, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
   const body = await response.json();
   if (response.status !== 200) {
     throw Error(body.message);

--- a/client/src/services/items/getAdminItems.js
+++ b/client/src/services/items/getAdminItems.js
@@ -1,8 +1,16 @@
-export const getAdminItems = async (isCurrent, limit = 10, page = 1) => {
+export const getAdminItems = async ({
+  isCurrent,
+  limit = 10,
+  page = 1,
+  donorId = undefined,
+  shopperId = undefined,
+}) => {
   const response = await fetch(
     `/api/items/admin?isCurrent=${Boolean(
       isCurrent
-    )}&limit=${limit}&page=${page}`,
+    )}&limit=${limit}&page=${page}${donorId ? `&donorId=${donorId}` : ''}${
+      shopperId ? `&shopperId=${shopperId}` : ''
+    }`,
     {
       headers: {
         'Content-Type': 'application/json',

--- a/client/src/services/user/getPublicUsers.js
+++ b/client/src/services/user/getPublicUsers.js
@@ -1,0 +1,14 @@
+export const getPublicUsers = async (token) => {
+  const response = await fetch(`/api/users/public`, {
+    headers: {
+      'Content-Type': 'application/json',
+      'x-access-token': token,
+    },
+  });
+  const body = await response.json();
+  console.log({ body });
+  if (response.status !== 200) {
+    throw Error(body.message);
+  }
+  return body;
+};

--- a/client/src/services/user/getPublicUsers.js
+++ b/client/src/services/user/getPublicUsers.js
@@ -6,7 +6,6 @@ export const getPublicUsers = async (token) => {
     },
   });
   const body = await response.json();
-  console.log({ body });
   if (response.status !== 200) {
     throw Error(body.message);
   }

--- a/client/src/services/user/index.js
+++ b/client/src/services/user/index.js
@@ -13,3 +13,4 @@ export { authenticateUser } from './authenticateUser';
 export { getDonations } from './getDonations';
 export { updatePassword } from './updatePassword';
 export { getGYBDummyUser } from './getGYBDummyUser';
+export { getPublicUsers } from './getPublicUsers';

--- a/server/routes/api/items.js
+++ b/server/routes/api/items.js
@@ -54,7 +54,9 @@ router.get('/admin', async (req, res) => {
   const isCurrent = req.query.isCurrent === 'true';
   const limit = req.query.limit;
   const page = req.query.page;
-  const items = await getAdminItems(isCurrent, limit, page);
+  const donor = req.query.donorId;
+  const shopper = req.query.shopperId;
+  const items = await getAdminItems(isCurrent, limit, page, donor, shopper);
   res.json(items);
 });
 

--- a/server/routes/api/users.js
+++ b/server/routes/api/users.js
@@ -18,7 +18,7 @@ router.get('/', async (req, res) => {
   res.json(users);
 });
 
-// TODO
+// get all shoppers and donors (no admins)
 router.get('/public', async (req, res) => {
   const users = await listPublicUsers();
   res.json(users);

--- a/server/routes/api/users.js
+++ b/server/routes/api/users.js
@@ -7,6 +7,7 @@ const {
   deleteUser,
   getDonations,
   getGYBDummyUser,
+  listPublicUsers,
 } = require('../../services/users');
 
 // get users endpoint api/users
@@ -14,6 +15,12 @@ router.get('/', async (req, res) => {
   let type = req.query.type || 'all';
   let approvedStatus = req.query.approvedStatus || '';
   const users = await getAllUsers(type, approvedStatus);
+  res.json(users);
+});
+
+// TODO
+router.get('/public', async (req, res) => {
+  const users = await listPublicUsers();
   res.json(users);
 });
 

--- a/server/services/items.js
+++ b/server/services/items.js
@@ -230,7 +230,6 @@ const getAdminItems = async (
   const lim = parseInt(limit);
   const pge = parseInt(page);
 
-  //here type is current or past
   var conditions = {};
 
   try {

--- a/server/services/items.js
+++ b/server/services/items.js
@@ -1,4 +1,6 @@
+const { ObjectId } = require('bson');
 const Item = require('../models/Item');
+const User_ = require('../models/User');
 const { cloudinary } = require('../utils/cloudinary');
 
 const createItem = async (data) => {
@@ -218,12 +220,18 @@ const getShopperItems = async (userId, itemStatus) => {
 
 // There is now proper pagination on this endpoint as the quantity of results
 // combined with aggregations is resulting in timeouts...
-const getAdminItems = async (isCurrent, limit = 10, page = 1) => {
-  //here type is current or past
-  var conditions = {};
-
+const getAdminItems = async (
+  isCurrent,
+  limit = 10,
+  page = 1,
+  donor = undefined,
+  shopper = undefined
+) => {
   const lim = parseInt(limit);
   const pge = parseInt(page);
+
+  //here type is current or past
+  var conditions = {};
 
   try {
     if (isCurrent) {
@@ -241,6 +249,12 @@ const getAdminItems = async (isCurrent, limit = 10, page = 1) => {
       conditions = {
         status: 'received',
       };
+    }
+
+    if (donor) {
+      conditions.donorId = new ObjectId(donor);
+    } else if (shopper) {
+      conditions.shopperId = new ObjectId(shopper);
     }
 
     // For now we are always running the count although it would be sensible to

--- a/server/services/users.js
+++ b/server/services/users.js
@@ -138,6 +138,20 @@ const getAllUsers = async (type, approvedStatus) => {
   }
 };
 
+const listPublicUsers = async () => {
+  try {
+    const users = await User_.User.find(
+      { kind: { $in: ['shopper', 'donor'] } },
+      'firstName lastName kind'
+    ).lean();
+
+    return users;
+  } catch (error) {
+    console.error(`Error in listPublicUsers: ${error}`);
+    return { success: false, message: `Error in listPublicUsers: ${error}` };
+  }
+};
+
 const getDonations = async (approvedStatus) => {
   try {
     const donations = await User_.Donor.aggregate([
@@ -213,6 +227,7 @@ module.exports = {
   createUser,
   getUser,
   getAllUsers,
+  listPublicUsers,
   deleteUser,
   updateUser,
   updateDonor,


### PR DESCRIPTION
The endpoint is already paginated but the performance is still not amazing and the filtering, searching and sorting is broken since it all ran entirely on the client.

This resolves a few things:
1. We no longer fetch both current and past items on load, we pull current by default and there is a new dropdown to select either the current or past items view
2. We pull the full list of donor and shopper users on load and use this list in an autocomplete/dropdown input to allow searching for a public user and pulling only items where that user is shopper or donor

Still to do are filtering by category, status, tags; sorting; filtering by item name.... (filter by status needs some clarifications)