### PR TITLE
57 platform timeouts caused by long running queries

### DIFF
--- a/client/src/components/molecules/ItemsCollapsedList/ItemsCollapsedList.js
+++ b/client/src/components/molecules/ItemsCollapsedList/ItemsCollapsedList.js
@@ -8,7 +8,7 @@ import {
   ExpandButton,
   DeleteButton,
 } from './ItemsCollapsedList.styles';
-import { categories } from '../../../utils/constants';
+// import { categories } from '../../../utils/constants';
 import { name } from '../../../utils/helpers';
 import { adminAllItemStatus } from '../../atoms/ProgressBar/constants';
 
@@ -21,7 +21,7 @@ export const ItemsCollapsedList = ({
   expandRow,
   reOpen,
   admin,
-  allTags,
+  // allTags,
   editItemLiveStatus,
 }) => {
   const [selectedRowKeys, setSelectedRowKeys] = useState([]);
@@ -99,7 +99,7 @@ export const ItemsCollapsedList = ({
       title: 'Name',
       dataIndex: 'name',
       sorter: (a, b) => a.name.localeCompare(b.name),
-      ...getColumnSearchProps('name'),
+      ...(admin ? {} : getColumnSearchProps('name')),
     },
   ];
 
@@ -141,24 +141,24 @@ export const ItemsCollapsedList = ({
       dataIndex: 'category',
       className: 'fixedOnMobileSmall',
       sorter: (a, b) => a.category.localeCompare(b.category),
-      filters: categories.map((c) => {
-        return { text: c.name, value: c.id };
-      }),
-      filterMode: 'tree',
-      filterSearch: true,
-      onFilter: (value, record) => record.category.startsWith(value),
+      // filters: categories.map((c) => {
+      //   return { text: c.name, value: c.id };
+      // }),
+      // filterMode: 'tree',
+      // filterSearch: true,
+      // onFilter: (value, record) => record.category.startsWith(value),
     });
     columns.push({
       title: 'Status',
       dataIndex: 'status',
       className: 'fixedOnMobileSmall',
       sorter: (a, b) => a.status.localeCompare(b.status),
-      filters: adminAllItemStatus.map((c) => {
-        return { text: c.statusText, value: c.status };
-      }),
-      filterMode: 'tree',
-      filterSearch: true,
-      onFilter: (value, record) => record.status.startsWith(value),
+      // filters: adminAllItemStatus.map((c) => {
+      //   return { text: c.statusText, value: c.status };
+      // }),
+      // filterMode: 'tree',
+      // filterSearch: true,
+      // onFilter: (value, record) => record.status.startsWith(value),
       render: (record) => {
         let value = adminAllItemStatus.find((x) => x.status === record);
         return value.statusText;
@@ -174,23 +174,23 @@ export const ItemsCollapsedList = ({
       dataIndex: 'shopper',
       render: (text) => text,
     });
-    columns.push({
-      title: 'Tags',
-      dataIndex: 'tags',
-      render: (record) => {
-        return record
-          .map((r) => {
-            return <span>r.name</span>;
-          })
-          .join();
-      },
-      className: 'onlyHeading',
-      filters: allTags.map((c) => {
-        return { text: c.name, value: c._id };
-      }),
-      filterMode: 'tree',
-      onFilter: (value, record) => record.tags.some((t) => t._id === value),
-    });
+    // columns.push({
+    //   title: 'Tags',
+    //   dataIndex: 'tags',
+    //   render: (record) => {
+    //     return record
+    //       .map((r) => {
+    //         return <span>r.name</span>;
+    //       })
+    //       .join();
+    //   },
+    //   className: 'onlyHeading',
+    //   filters: allTags.map((c) => {
+    //     return { text: c.name, value: c._id };
+    //   }),
+    //   filterMode: 'tree',
+    //   onFilter: (value, record) => record.tags.some((t) => t._id === value),
+    // });
   }
 
   if (handleDelete) {

--- a/client/src/components/organisms/Dashboard/AdminItems/AdminItems.js
+++ b/client/src/components/organisms/Dashboard/AdminItems/AdminItems.js
@@ -5,24 +5,26 @@ import React, {
   useEffect,
   useRef,
 } from 'react';
-import { AutoComplete, Modal, Select, Space } from 'antd';
+import { AutoComplete, Menu, Modal, Select, Space } from 'antd';
 import { AppContext } from '../../../../context/app-context';
 import { ItemCardLong, ItemsCollapsedList } from '../../../molecules';
 import { getAdminItems, deleteItem } from '../../../../services/items';
 import { getTags } from '../../../../services/tags';
 import { getPublicUsers } from '../../../../services/user';
 import { tabList } from '../../../../utils/helpers';
+import { categories } from '../../../../utils/constants';
+import { adminAllItemStatus } from '../../../atoms/ProgressBar/constants';
 
 export const AdminItems = () => {
   const { token, user } = useContext(AppContext);
   const mountedRef = useRef(true);
-  const [tags, setTags] = useState([]);
   const [users, setUsers] = useState([]);
   const [items, setItems] = useState([]);
   const [view, setView] = useState('current');
   const [totalItems, setTotalItems] = useState(0);
   const [currentPage, setCurrentPage] = useState(1);
   const [currentUser, setCurrentUser] = useState({});
+  const [conditions, setConditions] = useState([]);
 
   // Set this constant for now - we might want to allow adjustment later
   const limit = 10;
@@ -42,17 +44,32 @@ export const AdminItems = () => {
     const donorId = type === 'donor' ? value : undefined;
     const shopperId = type === 'shopper' ? value : undefined;
 
+    const { category, status } = conditions.reduce(
+      (acc, cur) => {
+        const [k, v] = cur.split(':');
+        acc[k] = acc[k] || [];
+        acc[k].push(v);
+        return acc;
+      },
+      {
+        category: undefined,
+        status: undefined,
+      }
+    );
+
     const { total, items } = await getAdminItems({
       isCurrent: view === 'current',
       page: currentPage,
       limit,
       donorId,
       shopperId,
+      category,
+      status,
     });
 
     setItems(items);
     setTotalItems(total);
-  }, [currentPage, currentUser, view]);
+  }, [conditions, currentPage, currentUser, view]);
 
   useEffect(() => {
     var tabs = tabList(user);
@@ -63,13 +80,15 @@ export const AdminItems = () => {
       }
     });
 
-    const fetchTags = async () => {
-      const tags = await getTags(token);
-      setTags(tags);
-    };
+    // const fetchTags = async () => {
+    //   const tags = await getTags(token);
+    //   console.log('HAHAH', tags);
+    //   setAllTags(tags);
+    // };
 
     const fetchUsers = async () => {
       const data = await getPublicUsers(token);
+      console.log('HOHOHO', data);
       setUsers(
         data.map((d) => ({
           label: `${d.firstName} ${d.lastName}`.trim(),
@@ -80,7 +99,7 @@ export const AdminItems = () => {
     };
 
     if (mountedRef.current) {
-      fetchTags();
+      // fetchTags();
       fetchUsers();
     }
 
@@ -115,8 +134,17 @@ export const AdminItems = () => {
   };
 
   const handleSelectView = (view) => {
+    setConditions([]);
     setCurrentPage(1);
     setView(view);
+  };
+
+  const handleSelectFilter = (e) => {
+    setConditions(
+      conditions.includes(e.key)
+        ? conditions.filter((i) => i !== e.key)
+        : [...conditions, e.key]
+    );
   };
 
   const handleSetPage = (page) => setCurrentPage(page);
@@ -137,6 +165,7 @@ export const AdminItems = () => {
         <Select
           size="large"
           style={{ width: 150 }}
+          value={view}
           placeholder="Items View"
           defaultValue="current"
           onSelect={handleSelectView}
@@ -163,6 +192,43 @@ export const AdminItems = () => {
           placeholder="Shopper or Donor"
           allowClear
         />
+
+        <Menu
+          triggerSubMenuAction="click"
+          onClick={handleSelectFilter}
+          selectedKeys={conditions}
+          multiple
+          mode="horizontal"
+          items={[
+            {
+              label: 'Category',
+              key: 'category',
+              children: categories.map((c) => ({
+                label: c.name,
+                key: `category:${c.id}`,
+              })),
+            },
+          ]}
+        />
+
+        <Menu
+          triggerSubMenuAction="click"
+          onClick={handleSelectFilter}
+          selectedKeys={conditions}
+          multiple
+          mode="horizontal"
+          items={[
+            {
+              label: 'Status',
+              key: 'status',
+              children: adminAllItemStatus.map((s) => ({
+                label: s.statusText,
+                key: `status:${s.status}`,
+                disabled: view === 'past' || s.status === 'received',
+              })),
+            },
+          ]}
+        />
       </Space>
 
       <ItemsCollapsedList
@@ -173,7 +239,7 @@ export const AdminItems = () => {
         expandRow={editForm}
         handleDelete={handleDeleteItem}
         admin={true}
-        allTags={tags}
+        allTags={[]}
       />
     </>
   );

--- a/client/src/components/organisms/Dashboard/AdminItems/AdminItems.js
+++ b/client/src/components/organisms/Dashboard/AdminItems/AdminItems.js
@@ -9,7 +9,7 @@ import { AutoComplete, Menu, Modal, Select, Space } from 'antd';
 import { AppContext } from '../../../../context/app-context';
 import { ItemCardLong, ItemsCollapsedList } from '../../../molecules';
 import { getAdminItems, deleteItem } from '../../../../services/items';
-import { getTags } from '../../../../services/tags';
+// import { getTags } from '../../../../services/tags';
 import { getPublicUsers } from '../../../../services/user';
 import { tabList } from '../../../../utils/helpers';
 import { categories } from '../../../../utils/constants';

--- a/client/src/components/organisms/Dashboard/AdminItems/AdminItems.js
+++ b/client/src/components/organisms/Dashboard/AdminItems/AdminItems.js
@@ -88,7 +88,7 @@ export const AdminItems = () => {
 
     const fetchUsers = async () => {
       const data = await getPublicUsers(token);
-      console.log('HOHOHO', data);
+
       setUsers(
         data.map((d) => ({
           label: `${d.firstName} ${d.lastName}`.trim(),

--- a/client/src/services/items/getAdminItems.js
+++ b/client/src/services/items/getAdminItems.js
@@ -4,6 +4,8 @@ export const getAdminItems = async ({
   page = 1,
   donorId = undefined,
   shopperId = undefined,
+  category = undefined,
+  status = undefined,
 }) => {
   const params = new URLSearchParams({ isCurrent, limit, page });
 
@@ -11,6 +13,14 @@ export const getAdminItems = async ({
     params.set('donorId', donorId);
   } else if (shopperId) {
     params.set('shopperId', shopperId);
+  }
+
+  if (category) {
+    params.set('category', category.join(','));
+  }
+
+  if (status) {
+    params.set('status', status.join(','));
   }
 
   const response = await fetch(`/api/items/admin?${params.toString()}`, {

--- a/server/routes/api/items.js
+++ b/server/routes/api/items.js
@@ -49,6 +49,7 @@ router.get('/donor', async (req, res) => {
   res.json(items);
 });
 
+// TODO this should probably be a POST endoint
 // get admin items endpoint api/items
 router.get('/admin', async (req, res) => {
   const isCurrent = req.query.isCurrent === 'true';
@@ -56,7 +57,17 @@ router.get('/admin', async (req, res) => {
   const page = req.query.page;
   const donor = req.query.donorId;
   const shopper = req.query.shopperId;
-  const items = await getAdminItems(isCurrent, limit, page, donor, shopper);
+  const category = req.query.category;
+  const status = req.query.status;
+  const items = await getAdminItems({
+    isCurrent,
+    limit,
+    page,
+    donor,
+    shopper,
+    category,
+    status,
+  });
   res.json(items);
 });
 

--- a/server/services/items.js
+++ b/server/services/items.js
@@ -220,13 +220,15 @@ const getShopperItems = async (userId, itemStatus) => {
 
 // There is now proper pagination on this endpoint as the quantity of results
 // combined with aggregations is resulting in timeouts...
-const getAdminItems = async (
+const getAdminItems = async ({
   isCurrent,
   limit = 10,
   page = 1,
   donor = undefined,
-  shopper = undefined
-) => {
+  shopper = undefined,
+  category = undefined,
+  status = undefined,
+}) => {
   const lim = parseInt(limit);
   const pge = parseInt(page);
 
@@ -234,22 +236,41 @@ const getAdminItems = async (
 
   try {
     if (isCurrent) {
-      conditions = {
-        approvedStatus: 'approved',
-        $or: [
-          { status: 'in-shop' },
-          { status: 'shopped' },
-          { status: 'shipped-to-gyb' },
-          { status: 'received-by-gyb' },
-          { status: 'shipped-to-shopper' },
-        ],
-      };
+      // Statuses comprising 'current' items
+      const defaultStatus = [
+        'in-shop',
+        'shopped',
+        'shipped-by-gyb',
+        'received-by-gyb',
+        'shipped-to-shopper',
+      ];
+      // all current items must be approved
+      const $and = [{ approvedStatus: 'approved' }];
+      // Apply either the statuses prvided by the client or the defaults
+      if (status) {
+        $and.push({
+          $or: status.split(',').map((s) => ({ status: s })),
+        });
+      } else {
+        $and.push({
+          $or: defaultStatus.map((s) => ({ status: s })),
+        });
+      }
+      // Apply categories if provided by the client
+      if (category) {
+        $and.push({
+          $or: category.split(',').map((c) => ({ category: c })),
+        });
+      }
+      conditions = { $and };
     } else {
+      // Past items are items that are confirmed received
       conditions = {
         status: 'received',
       };
     }
 
+    // Apply the donor or shopper id if any
     if (donor) {
       conditions.donorId = new ObjectId(donor);
     } else if (shopper) {

--- a/server/services/tags.js
+++ b/server/services/tags.js
@@ -4,6 +4,8 @@ const User_ = require('../models/User');
 
 const getTags = async () => {
   try {
+    // TODO this is an incredibly slow query and from what I can see we can
+    // probablt abandon the populate lookups entirely...
     const tags = await Tag.find({}).populate('items').populate('users');
     return tags;
   } catch (error) {


### PR DESCRIPTION
Third part for this issue:

Having switched to pagination for the admin items view (due to timeouts), we broke all the search/sort/filter utility in the view as it was all based on the full data being available on the client - previous PR restored search by item shopper or item donor, this PR restores filter by category and status....