### PR TITLE
57 platform timeouts caused by long running queries

### DIFF
--- a/client/src/components/molecules/DonorOrdersList/DonorOrdersList.js
+++ b/client/src/components/molecules/DonorOrdersList/DonorOrdersList.js
@@ -13,6 +13,7 @@ import {
 } from './DonorOrdersList.styles';
 import { getDonorItems, updateItem } from '../../../services/items';
 import { H2, Button } from '../../atoms';
+import { getTags } from '../../../services/tags';
 import { getUser } from '../../../services/user';
 import { getLocation } from '../../../services/locations';
 import {
@@ -25,6 +26,7 @@ import { ItemCardLong } from '../ItemCardLong';
 
 export const DonorOrdersList = () => {
   const { token, user, basket } = useContext(AppContext);
+  const [allTags, setAllTags] = useState([]);
   const [itemsToSend, setItemsToSend] = useState([]);
   const [itemsAwaitingReceived, setItemsAwaitingReceived] = useState([]);
   const mountedRef = useRef(true);
@@ -95,16 +97,25 @@ export const DonorOrdersList = () => {
       }
     });
 
+    // const fetchAllTags = async () => {
+    //   const tags = await getTags(token);
+    //   setAllTags(tags);
+    // };
+
+    const fetchAllTags = () =>
+      getTags(token).then(setAllTags).catch(console.warn);
+
     const fetchDonorItems = async () => {
       const items = await getDonorItems(user.id);
-      console.log('ITEMS NOW', items);
-      if (!mountedRef.current) return null;
       const itemsOrdered = donorItemsOrdering(items);
       setItemsToSend(itemsOrdered[0]);
       setItemsAwaitingReceived(itemsOrdered[1]);
     };
 
-    fetchDonorItems();
+    if (mountedRef.current) {
+      fetchAllTags();
+      fetchDonorItems();
+    }
 
     return () => {
       // cleanup
@@ -137,6 +148,7 @@ export const DonorOrdersList = () => {
                                 type={user.type}
                                 actionText={''}
                                 action={null}
+                                allTags={allTags}
                               />
                             </div>
                           );
@@ -173,6 +185,7 @@ export const DonorOrdersList = () => {
                             type={user.type}
                             actionText={''}
                             action={null}
+                            allTags={allTags}
                           />
                         </ShopperWrapperSmall>
                       );
@@ -192,6 +205,7 @@ export const DonorOrdersList = () => {
                                 type={user.type}
                                 actionText={''}
                                 action={null}
+                                allTags={allTags}
                               />
                             </div>
                           );

--- a/client/src/components/molecules/DonorOrdersList/DonorOrdersList.js
+++ b/client/src/components/molecules/DonorOrdersList/DonorOrdersList.js
@@ -1,5 +1,6 @@
 import React, { useContext, useState, useEffect, useRef } from 'react';
 import { AppContext } from '../../../context/app-context';
+import { AccountContext } from '../../../context/account-context';
 import { Modal } from 'antd';
 import {
   ListWrapper,
@@ -13,7 +14,6 @@ import {
 } from './DonorOrdersList.styles';
 import { getDonorItems, updateItem } from '../../../services/items';
 import { H2, Button } from '../../atoms';
-import { getTags } from '../../../services/tags';
 import { getUser } from '../../../services/user';
 import { getLocation } from '../../../services/locations';
 import {
@@ -26,7 +26,7 @@ import { ItemCardLong } from '../ItemCardLong';
 
 export const DonorOrdersList = () => {
   const { token, user, basket } = useContext(AppContext);
-  const [allTags, setAllTags] = useState([]);
+  const { allTags } = useContext(AccountContext);
   const [itemsToSend, setItemsToSend] = useState([]);
   const [itemsAwaitingReceived, setItemsAwaitingReceived] = useState([]);
   const mountedRef = useRef(true);
@@ -97,14 +97,6 @@ export const DonorOrdersList = () => {
       }
     });
 
-    // const fetchAllTags = async () => {
-    //   const tags = await getTags(token);
-    //   setAllTags(tags);
-    // };
-
-    const fetchAllTags = () =>
-      getTags(token).then(setAllTags).catch(console.warn);
-
     const fetchDonorItems = async () => {
       const items = await getDonorItems(user.id);
       const itemsOrdered = donorItemsOrdering(items);
@@ -113,7 +105,6 @@ export const DonorOrdersList = () => {
     };
 
     if (mountedRef.current) {
-      fetchAllTags();
       fetchDonorItems();
     }
 

--- a/client/src/components/molecules/ItemCardLong/ItemCardLong.js
+++ b/client/src/components/molecules/ItemCardLong/ItemCardLong.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useEffect, useRef } from 'react';
+import React, { useState, useContext } from 'react';
 import { AppContext } from '../../../context/app-context';
 import { useHistory } from 'react-router-dom';
 import {
@@ -12,7 +12,6 @@ import { Card as AntCard, Modal } from 'antd';
 import { Button } from '../../atoms';
 import { getLocation } from '../../../services/locations';
 import { getUser } from '../../../services/user';
-import { getTags } from '../../../services/tags';
 import { ProgressBar } from '../../atoms/ProgressBar/ProgressBar';
 import { Tags } from '../../organisms';
 import {
@@ -25,14 +24,12 @@ import {
 
 const { Meta } = AntCard;
 
-export const ItemCardLong = ({ item, actionText, action, type }) => {
+export const ItemCardLong = ({ item, actionText, action, type, allTags }) => {
   const { token } = useContext(AppContext);
-  const mountedRef = useRef(true);
   let history = useHistory();
   const [deliveryAddress, setDeliveryAddress] = useState({});
   const [addressFound, setAddressFound] = useState(false);
   const [FAOshopperName, setFAOShopperName] = useState('');
-  const [allTags, setAllTags] = useState([]);
 
   const additionalItemDetails =
     type === 'all' || type === 'admin' ? getItemDetails(item) : false;
@@ -101,22 +98,6 @@ export const ItemCardLong = ({ item, actionText, action, type }) => {
       setAddressFound(true);
     }
   };
-
-  useEffect(() => {
-    const fetchAllTags = async () => {
-      const tags = await getTags(token);
-      if (!mountedRef.current) return null;
-      setAllTags(tags);
-    };
-
-    fetchAllTags();
-
-    return () => {
-      // cleanup
-      mountedRef.current = false;
-    };
-    // eslint-disable-next-line
-  }, [token]);
 
   return (
     //some of the olf cloudinary images are not secure urls so forcing the change here

--- a/client/src/components/molecules/ItemsCollapsedList/ItemsCollapsedList.js
+++ b/client/src/components/molecules/ItemsCollapsedList/ItemsCollapsedList.js
@@ -16,7 +16,7 @@ export const ItemsCollapsedList = ({
   data,
   total,
   current,
-  onChange,
+  onChange: handleChange,
   handleDelete,
   expandRow,
   reOpen,
@@ -227,7 +227,7 @@ export const ItemsCollapsedList = ({
         onChange={(pagination, _filters, sorter) => {
           const { current } = pagination;
           const { field, order } = sorter;
-          onChange({ current, field, order });
+          handleChange({ current, field, order });
         }}
         columns={columns}
         rowKey={(record) => record._id || 0}

--- a/client/src/components/molecules/OrdersList/OrdersList.js
+++ b/client/src/components/molecules/OrdersList/OrdersList.js
@@ -1,5 +1,6 @@
 import React, { useContext, useState, useEffect, useRef } from 'react';
 import { AppContext } from '../../../context/app-context';
+import { AccountContext } from '../../../context/account-context';
 import { Modal } from 'antd';
 import {
   ListWrapper,
@@ -15,7 +16,6 @@ import {
   updateItem,
 } from '../../../services/items';
 import { H2, Button } from '../../atoms';
-import { getTags } from '../../../services/tags';
 import { getUser } from '../../../services/user';
 import { getLocation } from '../../../services/locations';
 import { getSetting } from '../../../services/settings';
@@ -30,9 +30,9 @@ import { ItemCardLong } from '../ItemCardLong';
 
 export const OrdersList = () => {
   const { token, user, basket } = useContext(AppContext);
+  const { allTags } = useContext(AccountContext);
   const [items, setItems] = useState([]);
   const [pastItems, setPastItems] = useState([]);
-  const [allTags, setAllTags] = useState([]);
   const mountedRef = useRef(true);
   const [shopRemaining, setShopRemaining] = useState(0);
   const [shopRemainingChildren, setShopRemainingChildren] = useState(0);
@@ -172,14 +172,6 @@ export const OrdersList = () => {
       }
     });
 
-    // const fetchAllTags = async () => {
-    //   const tags = await getTags(token);
-    //   setAllTags(tags);
-    // };
-
-    const fetchAllTags = () =>
-      getTags(token).then(setAllTags).catch(console.warn);
-
     const fetchShopperItems = async () => {
       const items = await getShopperItems(user.id);
       setItems(items);
@@ -218,7 +210,6 @@ export const OrdersList = () => {
     };
 
     if (mountedRef.current) {
-      fetchAllTags();
       if (user.type === 'shopper') {
         fetchShopperItems();
         fetchShopperPastItems();

--- a/client/src/components/molecules/UsersList/UsersList.js
+++ b/client/src/components/molecules/UsersList/UsersList.js
@@ -13,7 +13,7 @@ export const UsersList = ({
   data: rows,
   handleDelete,
   expandRow,
-  onExpand: handleOnExpand,
+  onExpand: handleExpand,
 }) => {
   const searchInput = useRef(null);
 
@@ -129,13 +129,25 @@ export const UsersList = ({
       key: 'action',
       render: (record) => (
         <Space size="middle">
-          <DeleteButton onClick={() => handleDelete(record._id, record.kind)}>
+          <DeleteButton onClick={() => handleDelete(record._id, record.type)}>
             Delete
           </DeleteButton>
         </Space>
       ),
     });
   }
+
+  const expandableProps = {
+    ...(handleExpand ? { onExpand: handleExpand } : {}),
+    expandedRowRender: expandRow,
+    expandIconColumnIndex: 2,
+    expandIcon: ({ expanded, onExpand, record }) =>
+      expanded ? (
+        <ExpandButton onClick={(e) => onExpand(record, e)}>Close</ExpandButton>
+      ) : (
+        <ExpandButton onClick={(e) => onExpand(record, e)}>View</ExpandButton>
+      ),
+  };
 
   return (
     <ListWrapper>
@@ -145,21 +157,7 @@ export const UsersList = ({
         scroll={{ x: '100%' }}
         columns={columns}
         rowKey={(record) => record._id}
-        expandable={{
-          onExpand: handleOnExpand,
-          expandedRowRender: expandRow,
-          expandIconColumnIndex: 2,
-          expandIcon: ({ expanded, onExpand, record }) =>
-            expanded ? (
-              <ExpandButton onClick={(e) => onExpand(record, e)}>
-                Close
-              </ExpandButton>
-            ) : (
-              <ExpandButton onClick={(e) => onExpand(record, e)}>
-                View
-              </ExpandButton>
-            ),
-        }}
+        expandable={expandableProps}
         dataSource={rows}
       />
     </ListWrapper>

--- a/client/src/components/molecules/UsersList/UsersList.js
+++ b/client/src/components/molecules/UsersList/UsersList.js
@@ -9,15 +9,14 @@ import {
 } from './UsersList.styles';
 import { name } from '../../../utils/helpers';
 
-export const UsersList = ({ data, handleDelete, expandRow, allTags }) => {
+export const UsersList = ({
+  data: rows,
+  handleDelete,
+  expandRow,
+  onExpand: handleOnExpand,
+}) => {
   const searchInput = useRef(null);
 
-  const rows = data.map((d) => {
-    return {
-      ...d,
-      name: name(d),
-    };
-  });
   const handleSearch = (selectedKeys, confirm) => {
     confirm();
   };
@@ -102,27 +101,27 @@ export const UsersList = ({ data, handleDelete, expandRow, allTags }) => {
     },
   ];
 
-  //additional tag column if shopper and donor list
-  if (allTags) {
-    columns.push({
-      title: 'Tags',
-      dataIndex: 'tags',
-      render: (record) => {
-        return record
-          .map((r) => {
-            return <span key={r.name}>r.name</span>;
-          })
-          .join();
-      },
-      className: 'onlyHeading',
-      filters: allTags.map((c) => {
-        return { text: c.name, value: c._id };
-      }),
-      filterMode: 'tree',
-      filterSearch: true,
-      onFilter: (value, record) => record.tags.some((t) => t._id === value),
-    });
-  }
+  // //additional tag column if shopper and donor list
+  // if (allTags) {
+  //   columns.push({
+  //     title: 'Tags',
+  //     dataIndex: 'tags',
+  //     render: (record) => {
+  //       return record
+  //         .map((r) => {
+  //           return <span key={r.name}>r.name</span>;
+  //         })
+  //         .join();
+  //     },
+  //     className: 'onlyHeading',
+  //     filters: allTags.map((c) => {
+  //       return { text: c.name, value: c._id };
+  //     }),
+  //     filterMode: 'tree',
+  //     filterSearch: true,
+  //     onFilter: (value, record) => record.tags.some((t) => t._id === value),
+  //   });
+  // }
 
   if (handleDelete) {
     columns.push({
@@ -147,6 +146,7 @@ export const UsersList = ({ data, handleDelete, expandRow, allTags }) => {
         columns={columns}
         rowKey={(record) => record._id}
         expandable={{
+          onExpand: handleOnExpand,
           expandedRowRender: expandRow,
           expandIconColumnIndex: 2,
           expandIcon: ({ expanded, onExpand, record }) =>

--- a/client/src/components/molecules/UsersList/UsersList.js
+++ b/client/src/components/molecules/UsersList/UsersList.js
@@ -10,12 +10,19 @@ import {
 import { name } from '../../../utils/helpers';
 
 export const UsersList = ({
-  data: rows,
+  data,
   handleDelete,
   expandRow,
   onExpand: handleExpand,
 }) => {
   const searchInput = useRef(null);
+
+  const rows = data.map((d) => {
+    return {
+      ...d,
+      name: d.name || name(d),
+    };
+  });
 
   const handleSearch = (selectedKeys, confirm) => {
     confirm();

--- a/client/src/components/organisms/Dashboard/AdminItems/AdminItems.js
+++ b/client/src/components/organisms/Dashboard/AdminItems/AdminItems.js
@@ -21,11 +21,11 @@ export const AdminItems = () => {
 
   // Transform the users data from context to a formatted autocomplete options
   // list with all admins excluded...
-  const publicUserOptions = (allUsers || []).reduce((acc, cur) => {
+  const publicUserOptions = Object.values(allUsers || {}).reduce((acc, cur) => {
     cur.type !== 'admin' &&
       acc.push({
         label: cur.name,
-        value: cur.id,
+        value: cur._id,
         type: cur.type,
       });
 

--- a/client/src/components/organisms/Dashboard/AdminItems/AdminItems.js
+++ b/client/src/components/organisms/Dashboard/AdminItems/AdminItems.js
@@ -9,7 +9,7 @@ import { AutoComplete, Menu, Modal, Select, Space } from 'antd';
 import { AppContext } from '../../../../context/app-context';
 import { ItemCardLong, ItemsCollapsedList } from '../../../molecules';
 import { getAdminItems, deleteItem } from '../../../../services/items';
-// import { getTags } from '../../../../services/tags';
+import { getTags } from '../../../../services/tags';
 import { getPublicUsers } from '../../../../services/user';
 import { tabList } from '../../../../utils/helpers';
 import { categories } from '../../../../utils/constants';
@@ -20,6 +20,7 @@ export const AdminItems = () => {
   const mountedRef = useRef(true);
   const [users, setUsers] = useState([]);
   const [items, setItems] = useState([]);
+  const [allTags, setAllTags] = useState([]);
   const [view, setView] = useState('current');
   const [itemsCount, setItemsCount] = useState(0);
   const [currentPage, setCurrentPage] = useState(1);
@@ -84,11 +85,10 @@ export const AdminItems = () => {
       }
     });
 
-    // const fetchTags = async () => {
-    //   const tags = await getTags(token);
-    //   console.log('HAHAH', tags);
-    //   setAllTags(tags);
-    // };
+    const fetchTags = async () => {
+      const tags = await getTags(token);
+      setAllTags(tags);
+    };
 
     const fetchUsers = async () => {
       const data = await getPublicUsers(token);
@@ -103,7 +103,7 @@ export const AdminItems = () => {
     };
 
     if (mountedRef.current) {
-      // fetchTags();
+      fetchTags();
       fetchUsers();
     }
 
@@ -169,7 +169,7 @@ export const AdminItems = () => {
   const editForm = (record) => {
     return (
       <div key={record._id}>
-        <ItemCardLong item={record} type="all" />
+        <ItemCardLong item={record} type="all" allTags={allTags} />
       </div>
     );
   };

--- a/client/src/components/organisms/Dashboard/ApproveRequests/ApproveRequests.js
+++ b/client/src/components/organisms/Dashboard/ApproveRequests/ApproveRequests.js
@@ -13,6 +13,7 @@ import {
   updateUser,
   getDonations,
 } from '../../../../services/user';
+import { getTags } from '../../../../services/tags';
 import { updateItem } from '../../../../services/items';
 import { getSetting } from '../../../../services/settings';
 import { sendAutoEmail, tabList } from '../../../../utils/helpers';
@@ -30,6 +31,7 @@ import { Modal } from 'antd';
 export const ApproveRequests = () => {
   const { token, user } = useContext(AppContext);
   const mountedRef = useRef(true);
+  const [allTags, setAllTags] = useState([]);
   const [shoppers, setShoppers] = useState([]);
   const [donations, setDonations] = useState([]);
   const [errorMessage, setErrorMessage] = useState('');
@@ -112,7 +114,7 @@ export const ApproveRequests = () => {
       <div>
         {record.donationItems.map((item) => (
           <ItemBox key={item._id}>
-            <ItemCardLong item={item} />
+            <ItemCardLong item={item} allTags={allTags} />
             <Button primary small data-item-id={item._id} onClick={approve}>
               Approve
             </Button>
@@ -204,16 +206,21 @@ export const ApproveRequests = () => {
       }
     });
 
+    // const fetchAllTags = async () => {
+    //   const tags = await getTags(token);
+    //   setAllTags(tags);
+    // };
+
+    const fetchAllTags = () =>
+      getTags(token).then(setAllTags).catch(console.warn);
+
     const fetchShoppers = async () => {
       const users = await getUsers('shopper', 'in-progress', token);
-      if (!mountedRef.current) return null;
       setShoppers(users);
     };
 
     const fetchDonations = async () => {
       const donations = await getDonations('in-progress', token);
-      if (!mountedRef.current) return null;
-
       setDonations(
         donations.filter((item) => {
           return item.numOfDonationItems !== 0;
@@ -224,13 +231,15 @@ export const ApproveRequests = () => {
     const fetchSetting = async () => {
       if (!token) return null;
       const settingValue = await getSetting('trustedDonorLimit', token);
-      if (!mountedRef.current) return null;
       setTrustedDonorLimit(settingValue);
     };
 
-    fetchShoppers();
-    fetchDonations();
-    fetchSetting();
+    if (mountedRef.current) {
+      fetchAllTags();
+      fetchShoppers();
+      fetchDonations();
+      fetchSetting();
+    }
 
     return () => {
       mountedRef.current = false;

--- a/client/src/components/organisms/Dashboard/ApproveRequests/ApproveRequests.js
+++ b/client/src/components/organisms/Dashboard/ApproveRequests/ApproveRequests.js
@@ -1,5 +1,6 @@
 import React, { useContext, useState, useRef, useEffect } from 'react';
 import { AppContext } from '../../../../context/app-context';
+import { AccountContext } from '../../../../context/account-context';
 import {
   StyledTab,
   StyledTabList,
@@ -13,7 +14,6 @@ import {
   updateUser,
   getDonations,
 } from '../../../../services/user';
-import { getTags } from '../../../../services/tags';
 import { updateItem } from '../../../../services/items';
 import { getSetting } from '../../../../services/settings';
 import { sendAutoEmail, tabList } from '../../../../utils/helpers';
@@ -30,8 +30,8 @@ import { Modal } from 'antd';
 
 export const ApproveRequests = () => {
   const { token, user } = useContext(AppContext);
+  const { allTags } = useContext(AccountContext);
   const mountedRef = useRef(true);
-  const [allTags, setAllTags] = useState([]);
   const [shoppers, setShoppers] = useState([]);
   const [donations, setDonations] = useState([]);
   const [errorMessage, setErrorMessage] = useState('');
@@ -206,14 +206,6 @@ export const ApproveRequests = () => {
       }
     });
 
-    // const fetchAllTags = async () => {
-    //   const tags = await getTags(token);
-    //   setAllTags(tags);
-    // };
-
-    const fetchAllTags = () =>
-      getTags(token).then(setAllTags).catch(console.warn);
-
     const fetchShoppers = async () => {
       const users = await getUsers('shopper', 'in-progress', token);
       setShoppers(users);
@@ -235,7 +227,6 @@ export const ApproveRequests = () => {
     };
 
     if (mountedRef.current) {
-      fetchAllTags();
       fetchShoppers();
       fetchDonations();
       fetchSetting();

--- a/client/src/components/organisms/Dashboard/Notifications/Notifications.js
+++ b/client/src/components/organisms/Dashboard/Notifications/Notifications.js
@@ -20,6 +20,7 @@ import {
   getItem,
 } from '../../../../services/items';
 import { getAdminLocations } from '../../../../services/locations';
+import { getTags } from '../../../../services/tags';
 import { getUser } from '../../../../services/user';
 import {
   sendAutoEmail,
@@ -49,6 +50,7 @@ export const Notifications = () => {
   ] = useState([]);
   const [adminLocations, setAdminLocations] = useState([]);
   const [assignAddressId, setAssignAddressId] = useState('');
+  const [allTags, setAllTags] = useState([]);
 
   const handleOk = (values) => {
     setLoading(true);
@@ -189,11 +191,17 @@ export const Notifications = () => {
       });
     };
 
+    // const fetchAllTags = async () => {
+    //   const tags = await getTags(token);
+    //   setAllTags(tags);
+    // };
+
+    const fetchAllTags = () =>
+      getTags(token).then(setAllTags).catch(console.warn);
+
     const fetchShopItems = async () => {
       const items = await getShopNotificationsItems(token);
       const locations = await getAdminLocations('available', token);
-
-      if (!mountedRef.current) return null;
 
       setAdminLocations(locations);
       setShopNotificationsPendingAssign({
@@ -216,8 +224,6 @@ export const Notifications = () => {
 
     const fetchAccountItems = async () => {
       const items = await getAccountNotificationsItems(user.id, token);
-
-      if (!mountedRef.current) return null;
 
       setAccountNotificationsPendingReceive({
         key: 1,
@@ -246,8 +252,11 @@ export const Notifications = () => {
       });
     };
 
-    fetchShopItems();
-    fetchAccountItems();
+    if (mountedRef.current) {
+      fetchAllTags();
+      fetchShopItems();
+      fetchAccountItems();
+    }
 
     return () => {
       mountedRef.current = false;
@@ -265,6 +274,7 @@ export const Notifications = () => {
                 type={user.type}
                 actionText={record.actionDesc}
                 action={record.action}
+                allTags={allTags}
               />
             </div>
           );

--- a/client/src/components/organisms/Dashboard/Notifications/Notifications.js
+++ b/client/src/components/organisms/Dashboard/Notifications/Notifications.js
@@ -1,5 +1,6 @@
 import React, { useContext, useState, useEffect, useRef } from 'react';
 import { AppContext } from '../../../../context/app-context';
+import { AccountContext } from '../../../../context/account-context';
 import {
   StyledTab,
   StyledTabList,
@@ -20,7 +21,6 @@ import {
   getItem,
 } from '../../../../services/items';
 import { getAdminLocations } from '../../../../services/locations';
-import { getTags } from '../../../../services/tags';
 import { getUser } from '../../../../services/user';
 import {
   sendAutoEmail,
@@ -32,6 +32,7 @@ import { Modal } from 'antd';
 
 export const Notifications = () => {
   const { token, user } = useContext(AppContext);
+  const { allTags } = useContext(AccountContext);
   const mountedRef = useRef(true);
   const [loading, setLoading] = useState(false);
   const [visible, setVisible] = useState(false);
@@ -50,7 +51,6 @@ export const Notifications = () => {
   ] = useState([]);
   const [adminLocations, setAdminLocations] = useState([]);
   const [assignAddressId, setAssignAddressId] = useState('');
-  const [allTags, setAllTags] = useState([]);
 
   const handleOk = (values) => {
     setLoading(true);
@@ -191,14 +191,6 @@ export const Notifications = () => {
       });
     };
 
-    // const fetchAllTags = async () => {
-    //   const tags = await getTags(token);
-    //   setAllTags(tags);
-    // };
-
-    const fetchAllTags = () =>
-      getTags(token).then(setAllTags).catch(console.warn);
-
     const fetchShopItems = async () => {
       const items = await getShopNotificationsItems(token);
       const locations = await getAdminLocations('available', token);
@@ -253,7 +245,6 @@ export const Notifications = () => {
     };
 
     if (mountedRef.current) {
-      fetchAllTags();
       fetchShopItems();
       fetchAccountItems();
     }

--- a/client/src/components/organisms/Dashboard/Tabs/Tabs.js
+++ b/client/src/components/organisms/Dashboard/Tabs/Tabs.js
@@ -15,11 +15,18 @@ import { tabList } from '../../../../utils/helpers';
 import { getTags } from '../../../../services/tags';
 import { getUser, listUsers } from '../../../../services/user';
 
+// Note! This tabs "wrapper" is currently in use as the data loader for the new
+// "account" context - there are certain data we should only be loading if the
+// current user is an admin - we dont want to expose all users data to shoppers
+// or donors... this should all be restructured with dedicated contexts etc.
+
 export const Tabs = ({ itemId }) => {
   const [tabIndex, setTabIndex] = useState(0);
   const { token, user } = useContext(AppContext);
   const { setAllTags, setAllUsers, setCurrentUser } =
     useContext(AccountContext);
+
+  console.log({ user });
 
   var tabs = tabList(user);
 
@@ -46,14 +53,14 @@ export const Tabs = ({ itemId }) => {
     }, {});
 
   // Set all current users to the context as a hash map on the id
-  useEffect(
-    () =>
+  useEffect(() => {
+    // Only load all users data in an admin context
+    user.type === 'admin' &&
       listUsers(token)
         .then(buildTransformUsersHash)
         .then(setAllUsers)
-        .catch(console.warn),
-    [setAllUsers, token, user]
-  );
+        .catch(console.warn);
+  }, [setAllUsers, token, user]);
 
   // Set the full current user detail
   useEffect(

--- a/client/src/components/organisms/Dashboard/Tabs/Tabs.js
+++ b/client/src/components/organisms/Dashboard/Tabs/Tabs.js
@@ -26,8 +26,6 @@ export const Tabs = ({ itemId }) => {
   const { setAllTags, setAllUsers, setCurrentUser } =
     useContext(AccountContext);
 
-  console.log({ user });
-
   var tabs = tabList(user);
 
   useEffect(() => {

--- a/client/src/components/organisms/Dashboard/Tabs/Tabs.js
+++ b/client/src/components/organisms/Dashboard/Tabs/Tabs.js
@@ -13,12 +13,13 @@ import {
 import { AccountWelcome } from '../../../molecules/AccountWelcome';
 import { tabList } from '../../../../utils/helpers';
 import { getTags } from '../../../../services/tags';
-import { listUsers } from '../../../../services/user';
+import { getUser, listUsers } from '../../../../services/user';
 
 export const Tabs = ({ itemId }) => {
   const [tabIndex, setTabIndex] = useState(0);
   const { token, user } = useContext(AppContext);
-  const { setAllTags, setAllUsers } = useContext(AccountContext);
+  const { setAllTags, setAllUsers, setCurrentUser } =
+    useContext(AccountContext);
 
   var tabs = tabList(user);
 
@@ -52,6 +53,12 @@ export const Tabs = ({ itemId }) => {
         .then(setAllUsers)
         .catch(console.warn),
     [setAllUsers, token, user]
+  );
+
+  // Set the full current user detail
+  useEffect(
+    () => getUser(user.id, token).then(setCurrentUser).catch(console.warn),
+    [setCurrentUser, token, user]
   );
 
   // Set the current tags - not sure how useful this is tbh...

--- a/client/src/components/organisms/Dashboard/Tabs/Tabs.js
+++ b/client/src/components/organisms/Dashboard/Tabs/Tabs.js
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect, useCallback } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import { AppContext } from '../../../../context/app-context';
 import { AccountContext } from '../../../../context/account-context';
 import {
@@ -30,28 +30,31 @@ export const Tabs = ({ itemId }) => {
     });
   }, [itemId, tabs]);
 
-  // TODO
-  const setAllUsersTransformed = useCallback(
-    (data) =>
-      setAllUsers(
-        data.map(({ firstName, lastName, email, kind, _id }) => ({
-          name: `${firstName} ${lastName}`.trim(),
-          email,
-          id: _id,
-          _id,
-          type: kind,
-        }))
-      ),
-    [setAllUsers]
-  );
+  const buildTransformUsersHash = (data) =>
+    data.reduce((acc, cur) => {
+      const { firstName, lastName, email, kind, _id } = cur;
 
-  // TODO
+      acc[_id] = {
+        name: `${firstName} ${lastName}`.trim(),
+        email,
+        _id,
+        type: kind,
+      };
+
+      return acc;
+    }, {});
+
+  // Set all current users to the context as a hash map on the id
   useEffect(
-    () => listUsers(token).then(setAllUsersTransformed).catch(console.warn),
-    [setAllUsersTransformed, token, user]
+    () =>
+      listUsers(token)
+        .then(buildTransformUsersHash)
+        .then(setAllUsers)
+        .catch(console.warn),
+    [setAllUsers, token, user]
   );
 
-  // Set the current tags - not sure how usefult this is tbh...
+  // Set the current tags - not sure how useful this is tbh...
   useEffect(
     () => getTags(token).then(setAllTags).catch(console.warn),
     [setAllTags, token, user]

--- a/client/src/components/organisms/Dashboard/Tabs/Tabs.js
+++ b/client/src/components/organisms/Dashboard/Tabs/Tabs.js
@@ -1,5 +1,6 @@
-import React, { useContext, useState, useEffect } from 'react';
+import React, { useContext, useState, useEffect, useCallback } from 'react';
 import { AppContext } from '../../../../context/app-context';
+import { AccountContext } from '../../../../context/account-context';
 import {
   StyledTab,
   StyledTabList,
@@ -11,10 +12,14 @@ import {
 } from './Tabs.styles';
 import { AccountWelcome } from '../../../molecules/AccountWelcome';
 import { tabList } from '../../../../utils/helpers';
+import { getTags } from '../../../../services/tags';
+import { countUsers } from '../../../../services/user';
+import { listUsers } from '../../../../services/user';
 
 export const Tabs = ({ itemId }) => {
   const [tabIndex, setTabIndex] = useState(0);
-  const { user } = useContext(AppContext);
+  const { token, user } = useContext(AppContext);
+  const { setAllTags, setAllUsers } = useContext(AccountContext);
 
   var tabs = tabList(user);
 
@@ -25,6 +30,35 @@ export const Tabs = ({ itemId }) => {
       }
     });
   }, [itemId, tabs]);
+
+  // Runs five queries in parallel for speed - pull minimal lean result for all
+  // existing users from the db (maybe we want to exclude non-approved?)
+  const fetchAllUsers = useCallback(async () => {
+    const { total } = await countUsers(token);
+
+    const rem = total % 4;
+    const lim = (total - rem) / 4;
+
+    const data = await Promise.all(
+      [lim, lim, lim, lim, rem].map(async (limit, index) =>
+        listUsers(token, limit, index * limit)
+      )
+    );
+
+    setAllUsers(
+      [].concat(...data).map(({ firstName, lastName, email, kind, _id }) => ({
+        name: `${firstName} ${lastName}`.trim(),
+        email,
+        id: _id,
+        type: kind,
+      }))
+    );
+  }, [setAllUsers, token]);
+
+  useEffect(fetchAllUsers, [fetchAllUsers, token, user]);
+
+  // Set the current tags - not sure how usefult this is tbh...
+  useEffect(() => getTags(token).then(setAllTags), [setAllTags, token, user]);
 
   return (
     <DashboardMenuWrapper>

--- a/client/src/components/organisms/Dashboard/Users/Users.js
+++ b/client/src/components/organisms/Dashboard/Users/Users.js
@@ -14,7 +14,7 @@ import {
   updateDonor,
   updateShopper,
 } from '../../../../services/user';
-import { deleteDonorItems } from '../../../../services/items'; // TODO
+// import { deleteDonorItems } from '../../../../services/items'; // TODO
 import { Modal } from 'antd';
 import { Formik } from 'formik';
 import {

--- a/client/src/components/organisms/Dashboard/Users/Users.js
+++ b/client/src/components/organisms/Dashboard/Users/Users.js
@@ -1,5 +1,6 @@
 import React, { useContext, useState, useRef, useEffect } from 'react';
 import { AppContext } from '../../../../context/app-context';
+import { AccountContext } from '../../../../context/account-context';
 import {
   StyledTab,
   StyledTabList,
@@ -14,7 +15,6 @@ import {
   updateShopper,
 } from '../../../../services/user';
 import { deleteDonorItems } from '../../../../services/items';
-import { getTags } from '../../../../services/tags';
 import { Modal } from 'antd';
 import { Formik } from 'formik';
 import {
@@ -31,10 +31,10 @@ import { openHiddenTab, tabList } from '../../../../utils/helpers';
 export const Users = () => {
   const { confirm } = Modal;
   const { token, user } = useContext(AppContext);
+  const { allTags } = useContext(AccountContext);
   const mountedRef = useRef(true);
   const [shoppers, setShoppers] = useState([]);
   const [donors, setDonors] = useState([]);
-  const [tags, setTags] = useState([]);
   const [editingKey, setEditingKey] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
 
@@ -118,7 +118,7 @@ export const Users = () => {
         <Tags
           updateId={record._id}
           tagList={record.tags || []}
-          availableTags={tags}
+          availableTags={allTags}
           updateType="user"
         />
         <Space />
@@ -152,25 +152,18 @@ export const Users = () => {
 
     const fetchShoppers = async () => {
       const users = await getUsers('shopper', 'approved', token);
-      if (!mountedRef.current) return null;
       setShoppers(users);
     };
 
     const fetchDonors = async () => {
       const users = await getUsers('donor', 'approved', token);
-      if (!mountedRef.current) return null;
       setDonors(users);
     };
 
-    const fetchAllTags = async () => {
-      const tags = await getTags(token);
-      if (!mountedRef.current) return null;
-      setTags(tags);
-    };
-
-    fetchShoppers();
-    fetchDonors();
-    fetchAllTags();
+    if (mountedRef) {
+      fetchShoppers();
+      fetchDonors();
+    }
 
     return () => {
       // cleanup
@@ -200,7 +193,7 @@ export const Users = () => {
           data={shoppers}
           handleDelete={handleDelete}
           expandRow={editForm}
-          allTags={tags}
+          allTags={allTags}
         />
         <Button
           primary
@@ -217,7 +210,7 @@ export const Users = () => {
           data={donors}
           handleDelete={handleDelete}
           expandRow={editForm}
-          allTags={tags}
+          allTags={allTags}
         />
         <Button
           primary

--- a/client/src/components/organisms/Tags/Tags.js
+++ b/client/src/components/organisms/Tags/Tags.js
@@ -63,6 +63,8 @@ export const Tags = ({ updateId, updateType, tagList, availableTags }) => {
           tag.name = tag.label;
         }
 
+        console.log({ tag });
+
         const isLongTag = tag.name.length > 20;
         const tagElem = (
           <StyledTag

--- a/client/src/components/organisms/Tags/Tags.js
+++ b/client/src/components/organisms/Tags/Tags.js
@@ -63,8 +63,6 @@ export const Tags = ({ updateId, updateType, tagList, availableTags }) => {
           tag.name = tag.label;
         }
 
-        console.log({ tag });
-
         const isLongTag = tag.name.length > 20;
         const tagElem = (
           <StyledTag

--- a/client/src/context/account-context.js
+++ b/client/src/context/account-context.js
@@ -9,17 +9,20 @@ export const AccountProvider = ({ children }) => {
 
   const [allTags, setAllTags] = React.useState(null);
   const [allUsers, setAllUsers] = React.useState(null);
+  const [currentUser, setCurrentUser] = React.useState(null);
 
   console.log(user); // Depending on user type we will expose data or not
 
   const value = React.useMemo(
     () => ({
       allTags,
-      allUsers,
       setAllTags,
+      allUsers,
       setAllUsers,
+      currentUser,
+      setCurrentUser,
     }),
-    [allTags, allUsers]
+    [allTags, allUsers, currentUser]
   );
 
   return (

--- a/client/src/context/account-context.js
+++ b/client/src/context/account-context.js
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+import { AppContext } from './app-context';
+
+export const AccountContext = React.createContext();
+
+export const AccountProvider = ({ children }) => {
+  const { user } = React.useContext(AppContext);
+
+  const [allTags, setAllTags] = React.useState(null);
+  const [allUsers, setAllUsers] = React.useState(null);
+
+  console.log(user); // Depending on user type we will expose data or not
+
+  const value = React.useMemo(
+    () => ({
+      allTags,
+      allUsers,
+      setAllTags,
+      setAllUsers,
+    }),
+    [allTags, allUsers]
+  );
+
+  return (
+    <AccountContext.Provider value={value}>{children}</AccountContext.Provider>
+  );
+};

--- a/client/src/context/account-context.js
+++ b/client/src/context/account-context.js
@@ -1,17 +1,11 @@
 import * as React from 'react';
 
-import { AppContext } from './app-context';
-
 export const AccountContext = React.createContext();
 
 export const AccountProvider = ({ children }) => {
-  const { user } = React.useContext(AppContext);
-
   const [allTags, setAllTags] = React.useState(null);
   const [allUsers, setAllUsers] = React.useState(null);
   const [currentUser, setCurrentUser] = React.useState(null);
-
-  console.log(user); // Depending on user type we will expose data or not
 
   const value = React.useMemo(
     () => ({

--- a/client/src/pages/Dashboard/Dashboard.js
+++ b/client/src/pages/Dashboard/Dashboard.js
@@ -2,13 +2,16 @@ import * as React from 'react';
 import { useParams } from 'react-router-dom';
 import { Container } from '../../components';
 import { DashboardTabs } from '../../components/';
+import { AccountProvider } from '../../context/account-context';
 
 export const Dashboard = () => {
   const { itemId } = useParams();
 
   return (
     <Container data-testid="Dashboard">
-      <DashboardTabs itemId={itemId} />
+      <AccountProvider>
+        <DashboardTabs itemId={itemId} />
+      </AccountProvider>
     </Container>
   );
 };

--- a/client/src/services/user/countUsers.js
+++ b/client/src/services/user/countUsers.js
@@ -1,13 +1,16 @@
-export const getPublicUsers = async (token) => {
-  const response = await fetch(`/api/users/public`, {
+export const countUsers = async (token) => {
+  const response = await fetch(`/api/users/count`, {
     headers: {
       'Content-Type': 'application/json',
       'x-access-token': token,
     },
   });
+
   const body = await response.json();
+
   if (response.status !== 200) {
     throw Error(body.message);
   }
+
   return body;
 };

--- a/client/src/services/user/index.js
+++ b/client/src/services/user/index.js
@@ -13,4 +13,5 @@ export { authenticateUser } from './authenticateUser';
 export { getDonations } from './getDonations';
 export { updatePassword } from './updatePassword';
 export { getGYBDummyUser } from './getGYBDummyUser';
-export { getPublicUsers } from './getPublicUsers';
+export { listUsers } from './listUsers';
+export { countUsers } from './countUsers';

--- a/client/src/services/user/listUsers.js
+++ b/client/src/services/user/listUsers.js
@@ -1,0 +1,28 @@
+export const listUsers = async (token, limit, offset) => {
+  const params = new URLSearchParams();
+
+  if (limit) {
+    params.set('limit', limit);
+  }
+
+  if (offset) {
+    params.set('offset', offset);
+  }
+
+  const search = params.size ? `?${params.toString()}` : '';
+
+  const response = await fetch(`/api/users/list${search}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      'x-access-token': token,
+    },
+  });
+
+  const body = await response.json();
+
+  if (response.status !== 200) {
+    throw Error(body.message);
+  }
+
+  return body;
+};

--- a/server/routes/api/users.js
+++ b/server/routes/api/users.js
@@ -7,8 +7,9 @@ const {
   deleteUser,
   getDonations,
   getGYBDummyUser,
-  listAllUsers,
   countAllUsers,
+  listAllUsers,
+  listAllUsersPaginated,
 } = require('../../services/users');
 
 // get users endpoint api/users
@@ -30,10 +31,13 @@ router.get('/list', async (req, res) => {
   const limit = req.query.limit;
   const offset = req.query.offset;
 
-  const users = await listAllUsers(
-    limit ? Number(limit) : Infinity,
-    offset ? Number(offset) : 0
-  );
+  let users;
+
+  if (limit && offset) {
+    users = await listAllUsersPaginated(Number(limit), Number(offset));
+  } else {
+    users = listAllUsers();
+  }
 
   res.json(users);
 });

--- a/server/routes/api/users.js
+++ b/server/routes/api/users.js
@@ -7,7 +7,8 @@ const {
   deleteUser,
   getDonations,
   getGYBDummyUser,
-  listPublicUsers,
+  listAllUsers,
+  countAllUsers,
 } = require('../../services/users');
 
 // get users endpoint api/users
@@ -18,9 +19,22 @@ router.get('/', async (req, res) => {
   res.json(users);
 });
 
-// get all shoppers and donors (no admins)
-router.get('/public', async (req, res) => {
-  const users = await listPublicUsers();
+// count all the users - we should add conditions...
+router.get('/count', async (req, res) => {
+  const total = await countAllUsers();
+  res.json({ total });
+});
+
+// list all users with no condition on type etc - allows pagination
+router.get('/list', async (req, res) => {
+  const limit = req.query.limit;
+  const offset = req.query.offset;
+
+  const users = await listAllUsers(
+    limit ? Number(limit) : Infinity,
+    offset ? Number(offset) : 0
+  );
+
   res.json(users);
 });
 

--- a/server/services/items.js
+++ b/server/services/items.js
@@ -1,6 +1,6 @@
 const { ObjectId } = require('bson');
 const Item = require('../models/Item');
-const User_ = require('../models/User');
+// const User_ = require('../models/User'); TODO will use asap
 const { cloudinary } = require('../utils/cloudinary');
 
 const createItem = async (data) => {
@@ -458,6 +458,7 @@ const getAccountNotificationItems = async (adminUserId) => {
 };
 
 const getShopNotificationItems = async () => {
+  // TODO - testing this query - it reduces the load from 25s -> 2.5s
   // const shopperIds = await User_.Shopper.find({
   //   deliveryPreference: 'via-gyb',
   // })

--- a/server/services/items.js
+++ b/server/services/items.js
@@ -1,5 +1,6 @@
 const { ObjectId } = require('bson');
 const Item = require('../models/Item');
+const User_ = require('../models/User');
 const { cloudinary } = require('../utils/cloudinary');
 
 const createItem = async (data) => {
@@ -457,6 +458,60 @@ const getAccountNotificationItems = async (adminUserId) => {
 };
 
 const getShopNotificationItems = async () => {
+  // const shopperIds = await User_.Shopper.find({
+  //   deliveryPreference: 'via-gyb',
+  // })
+  //   .select('id')
+  //   .then((data) => {
+  //     return data.reduce((acc, cur) => {
+  //       acc[cur.id] = cur;
+  //       return acc;
+  //     }, {});
+  //   });
+
+  // const condition = {
+  //   $and: [
+  //     { approvedStatus: 'approved' },
+  //     { status: { $in: ['shopped', 'shipped-to-gyb', 'received-by-gyb'] } },
+  //   ],
+  // };
+
+  // const count = await Item.countDocuments(condition);
+
+  // const div = 14;
+  // const rem = count % div;
+  // const max = (count - rem) / div;
+
+  // const init = new Array(div).fill(max).concat([rem]).filter(Boolean);
+
+  // const data = await Promise.all(
+  //   init.map(async (limit, index) =>
+  //     Item.find(condition)
+  //       .limit(limit)
+  //       .skip(index * max)
+  //       .lean()
+  //   )
+  // );
+
+  // const result = [].concat(...data).reduce(
+  //   (acc, cur) => {
+  //     if (!shopperIds[cur.shopperId]) {
+  //       return acc;
+  //     }
+
+  //     if (cur.status === 'shopped' && cur.sendVia === null) {
+  //       acc[0].push(cur);
+  //     } else {
+  //       acc[1].push(cur);
+  //     }
+
+  //     return acc;
+  //   },
+  //   [[], []]
+  // );
+
+  // return result;
+
   const results = [];
 
   const pendingAssignQuery = {

--- a/server/services/tags.js
+++ b/server/services/tags.js
@@ -6,7 +6,7 @@ const getTags = async () => {
   try {
     // TODO this is an incredibly slow query and from what I can see we can
     // probablt abandon the populate lookups entirely...
-    const tags = await Tag.find({}).populate('items').populate('users');
+    const tags = await Tag.find({}).lean(); //.populate('items').populate('users');
     return tags;
   } catch (error) {
     console.error(`Error in get tags: ${error}`);

--- a/server/services/tags.js
+++ b/server/services/tags.js
@@ -4,8 +4,8 @@ const User_ = require('../models/User');
 
 const getTags = async () => {
   try {
-    // TODO this is an incredibly slow query and from what I can see we can
-    // probablt abandon the populate lookups entirely...
+    // TODO this is a very slow query due to lookups scanning the entire items
+    // and users collections - disabling the lookups as appear to be uneeded
     const tags = await Tag.find({}).lean(); //.populate('items').populate('users');
     return tags;
   } catch (error) {

--- a/server/services/users.js
+++ b/server/services/users.js
@@ -163,16 +163,19 @@ const listAllUsers = async () => {
   const condition = { approvedStatus: 'approved' };
 
   try {
-    const total = await User_.User.countDocuments(condition);
+    const count = await User_.User.countDocuments(condition);
 
-    const rem = total % 4;
-    const lim = (total - rem) / 4;
+    const div = 4;
+    const rem = count % div;
+    const max = (count - rem) / div;
+
+    const init = new Array(div).fill(max).concat([rem]).filter(Boolean);
 
     const data = await Promise.all(
-      [lim, lim, lim, lim, rem].filter(Boolean).map(async (limit, index) =>
+      init.map(async (limit, index) =>
         User_.User.find(condition)
           .limit(limit)
-          .skip(index * limit)
+          .skip(index * limit) //
           .select('firstName lastName email kind')
           .lean()
       )
@@ -180,7 +183,6 @@ const listAllUsers = async () => {
 
     const users = [].concat(...data);
 
-    console.log(data.length, total, users.length, lim, rem);
     return users;
   } catch (error) {
     console.error(`Error in listAllUsers: ${error}`);

--- a/server/services/users.js
+++ b/server/services/users.js
@@ -142,23 +142,24 @@ const getAllUsers = async (type, approvedStatus) => {
 // Count all users - we should add conditions handling here...
 const countAllUsers = () => User_.User.countDocuments();
 
-// // Minimal list handler with pagination
-// const listAllUsers = async (limit, offset) => {
-//   try {
-//     const users = await User_.User.find({})
-//       .limit(limit)
-//       .skip(offset)
-//       .select('firstName lastName email kind')
-//       .lean();
+// Minimal list handler with pagination
+const listAllUsersPaginated = async (limit, offset) => {
+  try {
+    const users = await User_.User.find({})
+      .limit(limit)
+      .skip(offset)
+      .select('firstName lastName email kind')
+      .lean();
 
-//     return users;
-//   } catch (error) {
-//     console.error(`Error in listAllUsers: ${error}`);
-//     return { success: false, message: `Error in listAllUsers: ${error}` };
-//   }
-// };
+    return users;
+  } catch (error) {
+    console.error(`Error in listAllUsers: ${error}`);
+    return { success: false, message: `Error in listAllUsers: ${error}` };
+  }
+};
 
-// TODO - Minimal list handler with pagination
+// Minimal list handler parallelised - pattern is useful and can be extracted to
+// a util or something for reuse...
 const listAllUsers = async () => {
   const condition = { approvedStatus: 'approved' };
 
@@ -175,7 +176,7 @@ const listAllUsers = async () => {
       init.map(async (limit, index) =>
         User_.User.find(condition)
           .limit(limit)
-          .skip(index * limit) //
+          .skip(index * limit)
           .select('firstName lastName email kind')
           .lean()
       )
@@ -265,8 +266,9 @@ module.exports = {
   createUser,
   getUser,
   getAllUsers,
-  listAllUsers,
   countAllUsers,
+  listAllUsers,
+  listAllUsersPaginated,
   deleteUser,
   updateUser,
   updateDonor,

--- a/server/services/users.js
+++ b/server/services/users.js
@@ -139,17 +139,22 @@ const getAllUsers = async (type, approvedStatus) => {
   }
 };
 
-const listPublicUsers = async () => {
+// Count all users - we should add conditions handling here...
+const countAllUsers = () => User_.User.countDocuments();
+
+// Minimal list handler with pagination
+const listAllUsers = async (limit, offset) => {
   try {
-    const users = await User_.User.find(
-      { kind: { $in: ['shopper', 'donor'] } },
-      'firstName lastName kind'
-    ).lean();
+    const users = await User_.User.find({})
+      .limit(limit)
+      .skip(offset)
+      .select('firstName lastName email kind')
+      .lean();
 
     return users;
   } catch (error) {
-    console.error(`Error in listPublicUsers: ${error}`);
-    return { success: false, message: `Error in listPublicUsers: ${error}` };
+    console.error(`Error in listAllUsers: ${error}`);
+    return { success: false, message: `Error in listAllUsers: ${error}` };
   }
 };
 
@@ -228,7 +233,8 @@ module.exports = {
   createUser,
   getUser,
   getAllUsers,
-  listPublicUsers,
+  listAllUsers,
+  countAllUsers,
   deleteUser,
   updateUser,
   updateDonor,


### PR DESCRIPTION
Quite a few aspects covered here, mainly:

- disabled population on the list tags endpoint - I could not see anywhere the populated data was being used and for each tag the population required us to scan the whole items collection as well as users...
- added a parallelised list all users lean handler for optimised minimal user data provision
- create a new 'account (admin really) context' for providing commonly used data to the admin panel views
- the main admin panel tabs component now doubles as a data loader, populating the account context with the commonly used data: all users, current user, all tags
- children of the tabs wrapper / admin context can now have direct access to tags and users data once it is loaded via context instead of loading it themselves
- children previously would dispatch all db queries and then check whether the data was needed based on a mounted status - avoid this by not running the queries at all if the condition check fails...