### PR TITLE
Item deletion is broken with Mongoose update

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -56,11 +56,7 @@ userSchema.methods.updatePassword = async (id, candidatePassword) => {
 
     bcrypt.hash(candidatePassword, salt, async (err, hash) => {
       if (err) throw err;
-      const user = await User.findOneAndUpdate(
-        { _id: id },
-        { password: hash },
-        { useFindAndModify: false }
-      );
+      const user = await User.findOneAndUpdate({ _id: id }, { password: hash });
       if (user) {
         return { success: true, message: `Password updated` };
       } else {

--- a/server/services/items.js
+++ b/server/services/items.js
@@ -180,7 +180,6 @@ const updateItem = async (id, updateData) => {
     }
     try {
       const item = await Item.findOneAndUpdate({ _id: id }, updateData, {
-        useFindAndModify: false,
         returnDocument: 'after',
       });
 
@@ -198,7 +197,6 @@ const updateItem = async (id, updateData) => {
     delete updateData.photos;
     try {
       const item = await Item.findOneAndUpdate({ _id: id }, updateData, {
-        useFindAndModify: false,
         returnDocument: 'after',
       });
 
@@ -217,7 +215,7 @@ const updateItem = async (id, updateData) => {
 
 const deleteItem = async (id) => {
   try {
-    const item = await Item.findOneAndDelete(id, { useFindAndModify: false });
+    const item = await Item.findByIdAndDelete(id);
     if (item) {
       return { success: true, message: 'Item deleted' };
     } else {
@@ -237,15 +235,13 @@ const deleteBatchItem = async (id) => {
     }
     const itemIds = batchItem.itemIds;
     const itemDeletionPromises = itemIds.map(async (itemId) => {
-      const deletedItem = await Item.findOneAndDelete(itemId, {
-        useFindAndModify: false,
-      });
+      const deletedItem = await Item.findByIdAndDelete(itemId);
       if (!deletedItem) {
         throw Error(`Cannot delete item with ID ${itemId}`);
       }
     });
     await Promise.all(itemDeletionPromises);
-    await BatchItem.findOneAndDelete(id, { useFindAndModify: false });
+    await BatchItem.findByIdAndDelete(id);
     return { success: true, message: 'BatchItem and associated items deleted' };
   } catch (error) {
     console.error(`Error in deleteBatchItem: ${error}`);
@@ -623,10 +619,7 @@ const deleteDonorItems = async (id) => {
     throw Error('No donor id provided');
   }
   try {
-    const item = await Item.findOneAndDelete(
-      { donorId: id },
-      { useFindAndModify: false }
-    );
+    const item = await Item.findByIdAndDelete(id);
     if (item) {
       return { success: true, message: 'Donor items deleted' };
     } else {

--- a/server/services/locations.js
+++ b/server/services/locations.js
@@ -3,7 +3,6 @@ const Location = require('../models/Location');
 const updateLocation = async (id, updateData) => {
   try {
     const location = await Location.findOneAndUpdate({ _id: id }, updateData, {
-      useFindAndModify: false,
       returnDocument: 'after',
     });
     if (location) {
@@ -58,9 +57,7 @@ const getLocation = async (id) => {
 
 const deleteLocation = async (id) => {
   try {
-    const location = await Location.findByIdAndRemove(id, {
-      useFindAndModify: false,
-    });
+    const location = await Location.findByIdAndDelete(id);
     if (location) {
       return { success: true, message: 'location deleted' };
     } else {

--- a/server/services/messages.js
+++ b/server/services/messages.js
@@ -36,7 +36,7 @@ const markMessageAsViewed = async (id, messageIds) => {
     const thread = await Message.findOneAndUpdate(
       { _id: id, 'messages._id': { $in: messageIds } },
       { $set: { 'messages.$.viewed': true } },
-      { useFindAndModify: false, returnDocument: 'after' }
+      { returnDocument: 'after' }
     );
     if (thread) {
       return { success: true, message: 'marked as viewed', thread: thread };
@@ -64,7 +64,7 @@ const createMessage = async (data) => {
     const thread = await Message.findOneAndUpdate(
       { threadId: data.threadId },
       { $push: { messages: updateData } },
-      { useFindAndModify: false, returnDocument: 'after' }
+      { returnDocument: 'after' }
     ).then((t) =>
       t
         .populate('user')

--- a/server/services/settings.js
+++ b/server/services/settings.js
@@ -2,9 +2,7 @@ const Setting = require('../models/Settings');
 
 const updateSetting = async (name, data) => {
   try {
-    const setting = await Setting.findOneAndUpdate({ name: name }, data, {
-      useFindAndModify: false,
-    });
+    const setting = await Setting.findOneAndUpdate({ name: name }, data);
     if (setting) {
       return { success: true, message: 'setting updated' };
     } else {

--- a/server/services/tags.js
+++ b/server/services/tags.js
@@ -16,7 +16,7 @@ const getTags = async () => {
 
 const deleteTag = async (id) => {
   try {
-    const tag = await Tag.findByIdAndRemove(id, { useFindAndModify: false });
+    const tag = await Tag.findByIdAndDelete(id);
     if (tag) {
       return { success: true, message: 'tag deleted' };
     } else {
@@ -31,7 +31,6 @@ const deleteTag = async (id) => {
 const updateTag = async (id, updateData) => {
   try {
     const tag = await Tag.findOneAndUpdate({ _id: id }, updateData, {
-      useFindAndModify: false,
       returnDocument: 'after',
     });
     if (tag) {

--- a/server/services/users.js
+++ b/server/services/users.js
@@ -28,7 +28,6 @@ const createUser = async (data) => {
 const updateUser = async (id, updateData) => {
   try {
     const user = await User_.User.findOneAndUpdate({ _id: id }, updateData, {
-      useFindAndModify: false,
       returnDocument: 'after',
     });
     if (user) {
@@ -51,7 +50,6 @@ const updateDonor = async (id, updateData) => {
   }
   try {
     const user = await User_.Donor.findOneAndUpdate({ _id: id }, updateData, {
-      useFindAndModify: false,
       returnDocument: 'after',
     });
     if (user) {
@@ -68,7 +66,6 @@ const updateDonor = async (id, updateData) => {
 const updateShopper = async (id, updateData) => {
   try {
     const user = await User_.Shopper.findOneAndUpdate({ _id: id }, updateData, {
-      useFindAndModify: false,
       returnDocument: 'after',
     });
     if (user) {
@@ -85,7 +82,6 @@ const updateShopper = async (id, updateData) => {
 const updateAdmin = async (id, updateData) => {
   try {
     const user = await User_.Admin.findOneAndUpdate({ _id: id }, updateData, {
-      useFindAndModify: false,
       returnDocument: 'after',
     });
     if (user) {
@@ -101,9 +97,7 @@ const updateAdmin = async (id, updateData) => {
 
 const deleteUser = async (id) => {
   try {
-    const user = await User_.User.findByIdAndRemove(id, {
-      useFindAndModify: false,
-    });
+    const user = await User_.User.findByIdAndDelete(id);
     if (user) {
       return { success: true, message: 'User deleted' };
     } else {


### PR DESCRIPTION
- replace `findByIdAndRemove` and `findOneAndDelete` with `findByIdAndDelete` https://mongoosejs.com/docs/api/model.html#Model.findByIdAndDelete()
- remove deprecated query option `useFindAndModify` https://mongoosejs.com/docs/migrating_to_6.html#no-more-deprecation-warning-options