### PR TITLE
78 bulk items handling option for donor users

### DIFF
--- a/client/src/components/molecules/EditForm/DonorMiniEditForm.js
+++ b/client/src/components/molecules/EditForm/DonorMiniEditForm.js
@@ -40,6 +40,16 @@ export const DonorMiniEditForm = ({ editingKey, recordId, approvalAction }) => {
         <StyledError name="trustedDonor" component="div" />
       </div>
 
+      <div>
+        <StyledCheckbox
+          name="canAddItemInBulk"
+          disabled={editingKey !== recordId}
+        >
+          User can add items in bulk
+        </StyledCheckbox>
+        <StyledError name="canAddItemInBulk" component="div" />
+      </div>
+
       {editingKey === recordId && !approvalAction && (
         <StyledSubmitButton>Save</StyledSubmitButton>
       )}

--- a/client/src/components/molecules/EditForm/ItemCreateForm.js
+++ b/client/src/components/molecules/EditForm/ItemCreateForm.js
@@ -27,6 +27,8 @@ export const ItemCreateForm = (data) => {
   const [selectedCategory, setSelectedCategory] = useState('');
   const [selectedSubCategory, setSelectedSubCategory] = useState('');
 
+  console.log({ user });
+
   const handleCategoryChange = (category, subCategory) => {
     setSelectedCategory(category);
     setSelectedSubCategory(subCategory);
@@ -75,8 +77,15 @@ export const ItemCreateForm = (data) => {
         onSubmit={handleSubmit}
       >
         <Form>
-          <StyledLabel>Bulk Item?</StyledLabel>
-          <StyledSwitch name="showBatchOptions" onChange={handleSwitchChange} />
+          {user.canAddItemInBulk && (
+            <>
+              <StyledLabel>Bulk Item?</StyledLabel>
+              <StyledSwitch
+                name="showBatchOptions"
+                onChange={handleSwitchChange}
+              />
+            </>
+          )}
 
           <StyledLabel>
             Item Name

--- a/client/src/components/molecules/EditForm/ItemCreateForm.js
+++ b/client/src/components/molecules/EditForm/ItemCreateForm.js
@@ -27,8 +27,6 @@ export const ItemCreateForm = (data) => {
   const [selectedCategory, setSelectedCategory] = useState('');
   const [selectedSubCategory, setSelectedSubCategory] = useState('');
 
-  console.log({ user });
-
   const handleCategoryChange = (category, subCategory) => {
     setSelectedCategory(category);
     setSelectedSubCategory(subCategory);

--- a/server/controllers/authentication.js
+++ b/server/controllers/authentication.js
@@ -40,6 +40,7 @@ const setUserDetails = (user) => {
 
   if (user.kind === 'donor') {
     UserDetails.trustedDonor = user.trustedDonor || false;
+    UserDetails.canAddItemInBulk = user.canAddItemInBulk || false;
   }
 
   if (user.kind === 'shopper') {

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -89,6 +89,10 @@ const Donor = User.discriminator(
   new Schema(
     {
       trustedDonor: Boolean,
+      canAddItemInBulk: {
+        type: Boolean,
+        default: false,
+      },
     },
     options
   )


### PR DESCRIPTION
Adds boolean property on the donor user model for toggling allow bulk item uploads with UI for admins to update.

Migration to run on release: `db.users.updateMany({ kind: 'donor' }, { $set: { canAddItemInBulk: false } })`