### PR TITLE
added one-size option and fixed styling for quantities

### DIFF
--- a/client/src/components/molecules/EditForm/EditForm.styles.js
+++ b/client/src/components/molecules/EditForm/EditForm.styles.js
@@ -199,9 +199,10 @@ const StyledInputNumber = styled(InputNumber)`
     background-color: transparent;
     color: black;
   }
-  &.childrenShoeSize,
-  &.childrenClothingSize {
-    width: 100px;
+  &.clothingSize,
+  &.shoeSize {
+    width: 60px;
+    font-size: 17px;
   }
 `;
 
@@ -259,14 +260,11 @@ const StyledLabel = styled.label`
   font-size: 22px !important;
   &.shoeSize,
   &.clothingSize {
-    width: 40%;
-  }
-  &.shoeSize,
-  &.clothingSize,
-  &.childrenClothingSize,
-  &.childrenShoeSize {
+    margin-right: 10px;
+    width: 30%;
     font-size: 16px !important;
     @media (min-width: 525px) {
+      width: 20%;
       font-size: 18px !important;
     }
   }
@@ -333,52 +331,31 @@ const SizeQuantityContainer = styled.div`
   justify-content: flex-start;
   align-content: flex-start;
   align-items: flex-start;
-  height: 600px;
   width: 100%;
-  &.clothingSize,
-  &.shoeSize,
-  &.childrenClothingSize {
-    height: 550px;
+  &.clothingSize {
+    max-height: 450px;
     @media (min-width: 525px) {
-      height: 400px;
+      max-height: 300px;
     }
   }
-  &.childrenShoeSize {
-    height: 750px;
+  &.shoeSize {
+    max-height: 350px;
     @media (min-width: 525px) {
-      height: 600px;
+      max-height: 235px;
     }
   }
 `;
 
 const SizeQuantityPair = styled.div`
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   margin-bottom: 10px;
   margin-right: 10px;
-  &.clothingSize {
-    width: 50%;
-    @media (min-width: 525px) {
-      width: 30%;
-    }
-  }
+  &.clothingSize,
   &.shoeSize {
-    margin-right: 0;
     width: 50%;
     @media (min-width: 525px) {
-      width: 36%;
-    }
-  }
-  &.childrenClothingSize {
-    width: 40%;
-    @media (min-width: 525px) {
-      width: 36%;
-    }
-  }
-  &.childrenShoeSize {
-    width: 50%;
-    @media (min-width: 525px) {
-      width: 30%;
+      width: 35%;
     }
   }
   &:last-child {

--- a/client/src/components/molecules/EditForm/SizeSelector.js
+++ b/client/src/components/molecules/EditForm/SizeSelector.js
@@ -36,7 +36,7 @@ const SizeSelector = ({
   return (
     <div>
       <StyledLabel>{`${label} Quantities`}</StyledLabel>
-      <SizeQuantityContainer name="sizeQuantityContainer">
+      <SizeQuantityContainer name="sizeQuantityContainer" className={fieldName}>
         {sizeOptions.map((size) => (
           <SizeQuantityPair
             className={fieldName}

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -160,6 +160,8 @@ export const shoeSizeOptions = [
   '10',
 ];
 
+export const oneSizeOptions = ['One Size'];
+
 export const colours = [
   'Black',
   'Blue',

--- a/client/src/utils/sizeOptions.js
+++ b/client/src/utils/sizeOptions.js
@@ -3,6 +3,7 @@ import {
   // childrenClothingSizeOptions,
   shoeSizeOptions,
   clothingSizeOptions,
+  oneSizeOptions,
 } from './constants';
 
 export const sizeOptions = (category, subcategory) => {
@@ -45,9 +46,9 @@ export const sizeOptions = (category, subcategory) => {
     case 'accessories':
       sizeOptions = [
         {
-          sizeOption: clothingSizeOptions,
+          sizeOption: oneSizeOptions,
           fieldName: 'clothingSize',
-          label: 'Clothing Size',
+          label: 'Accessories Size',
         },
       ];
       break;
@@ -63,9 +64,9 @@ export const sizeOptions = (category, subcategory) => {
     case 'other':
       sizeOptions = [
         {
-          sizeOption: clothingSizeOptions,
+          sizeOption: oneSizeOptions,
           fieldName: 'clothingSize',
-          label: 'Clothing Size',
+          label: 'Other Size',
         },
       ];
       break;


### PR DESCRIPTION
- Added a 'one-size' option when the category is 'accessories' or 'other'. 
- Cleaned up the styling for the quantities, so now they are more in-line and clean with responsiveness on smaller screens.