### PR TITLE
removing bulk-items with zero quantity during creation

### DIFF
--- a/client/src/components/molecules/EditForm/SizeSelector.js
+++ b/client/src/components/molecules/EditForm/SizeSelector.js
@@ -26,25 +26,40 @@ const SizeSelector = ({
   }, [category, subcategory, setFieldValue]);
 
   const handleQuantityChange = (size, quantity) => {
-    const validQuantity = Math.max(quantity, 0);
-    const updatedQuantities = {
+    let updatedQuantities = {
       ...formikProps.values[`${fieldName}`],
-      [size]: validQuantity,
     };
 
-    // perform a sort on the selected sizes as this will be important when they are displayed.
-    let sizeOrder = [];
-    if (fieldName === 'shoeSizes') {
-      sizeOrder = shoeSizeOptions;
+    if (quantity === 0) {
+      // If quantity is 0, check if the size exists and remove it
+      // [case: when a user inputs a number but decides that's the wrong size and puts it back to zero, we don't want to record those in the db.]
+      if (Object.prototype.hasOwnProperty.call(updatedQuantities, size)) {
+        delete updatedQuantities[size];
+      }
     } else {
-      sizeOrder = clothingSizeOptions;
+      const validQuantity = Math.max(quantity, 1);
+      updatedQuantities = {
+        ...updatedQuantities,
+        [size]: validQuantity,
+      };
     }
-    const keyValueArray = Object.entries(updatedQuantities);
-    keyValueArray.sort(
-      (a, b) => sizeOrder.indexOf(a[0]) - sizeOrder.indexOf(b[0])
-    );
-    const sortedUpdatedQuantities = Object.fromEntries(keyValueArray);
-    setFieldValue(`${fieldName}`, sortedUpdatedQuantities);
+
+    // will still re-factor this to do the sorting once on the backend, but for now, I've added the extra check as it was failign a particular case in testing.
+    if (Object.keys(updatedQuantities).length > 0) {
+      // perform a sort on the selected sizes as this will be important when they are displayed.
+      let sizeOrder = [];
+      if (fieldName === 'shoeSizes') {
+        sizeOrder = shoeSizeOptions;
+      } else {
+        sizeOrder = clothingSizeOptions;
+      }
+      const keyValueArray = Object.entries(updatedQuantities);
+      keyValueArray.sort(
+        (a, b) => sizeOrder.indexOf(a[0]) - sizeOrder.indexOf(b[0])
+      );
+      const sortedUpdatedQuantities = Object.fromEntries(keyValueArray);
+      setFieldValue(`${fieldName}`, sortedUpdatedQuantities);
+    }
   };
 
   return (

--- a/client/src/pages/Item/Item.js
+++ b/client/src/pages/Item/Item.js
@@ -92,7 +92,6 @@ export const Item = () => {
       if (itemDetails.batchId && itemDetails.isTemplateBatchItem) {
         const batchItemData = await getBatchItem(itemDetails.batchId);
         const batchItem = batchItemData.batchItem;
-        console.log('batchItem: ', batchItem);
         if (
           batchItem.clothingSizes !== null &&
           batchItem.clothingSizes !== undefined &&


### PR DESCRIPTION
issue #42 

small fix when creating an item and the user has increased the quantity for a given size, but then brought it back down to zero (let's say they got it wrong initially), the quantity of 0 would have been saved to the db and falsely displayed (all-be-it greyed out and unavailable) to the user. 

This just gets rid of that altogether...


