### PR TITLE
small bug-fix batch item limit

### DIFF
--- a/client/src/pages/Item/AddBatchItemToBasket.js
+++ b/client/src/pages/Item/AddBatchItemToBasket.js
@@ -81,7 +81,7 @@ const AddBatchItemToBasketButton = ({
     const userLimit = calculateUserLimit(category);
     const recentItemsCount = calculateRecentItemsCount(category);
     const basketItemsCount = calculateBasketItemsCount(category);
-    const availableQuantity = userLimit - recentItemsCount + basketItemsCount;
+    const availableQuantity = userLimit - (recentItemsCount + basketItemsCount);
 
     if (!user || user.type !== 'shopper') {
       //if not signed in


### PR DESCRIPTION
Issue #42 

The order functionality for batch item was not calculating the limit correctly - classic high-school mathematics blunder of not including brackets around the operators that should take precedent :------)