### PR TITLE
Statistics & Report data now includes batch items

### DIFF
--- a/client/src/components/molecules/EditForm/ItemCreateForm.js
+++ b/client/src/components/molecules/EditForm/ItemCreateForm.js
@@ -22,6 +22,10 @@ import {
 import { Images } from '../Images';
 import { CategoryFields } from './CategoryFields';
 import RenderBatchOptions from './RenderBatchOptions';
+import {
+  sortQuantities,
+  calculateTotalQuantity,
+} from '../../../utils/batchItemHelpers';
 
 export const ItemCreateForm = (data) => {
   const { token, user } = useContext(AppContext);
@@ -39,24 +43,11 @@ export const ItemCreateForm = (data) => {
     setShowBatchOptions(checked);
   };
 
-  const sortQuantities = (formValues) => {
-    const fieldName =
-      formValues.shoeSizes.length > 0 ? 'shoeSizes' : 'clothingSizes';
-    const sizeOrder =
-      formValues.shoeSizes.length > 0 ? shoeSizeOptions : clothingSizeOptions;
-    const quantities = formValues[fieldName];
-    const keyValueArray = Object.entries(quantities);
-    keyValueArray.sort(
-      (a, b) => sizeOrder.indexOf(a[0]) - sizeOrder.indexOf(b[0])
-    );
-    const sortedQuantities = Object.fromEntries(keyValueArray);
-    return { ...formValues, [fieldName]: sortedQuantities };
-  };
-
   const handleSubmit = async (values, { resetForm, setFieldValue }) => {
     let res;
     if (showBatchOptions === true) {
       const sortedValues = sortQuantities(values);
+      sortedValues.quantity = calculateTotalQuantity(sortedValues);
       res = await createBatchItem(sortedValues, token);
     } else {
       res = await createItem(values, token);

--- a/client/src/components/molecules/Report/Report.js
+++ b/client/src/components/molecules/Report/Report.js
@@ -234,18 +234,16 @@ export const Report = () => {
       // tags worksheet rows
 
       res.data.tags.forEach((c) => {
-        if (c._id.length === 1 && c._id[0] !== '') {
-          //deleted tags sometimes return item data
-          sheetFour.addRow({
-            tag: c._id[0],
-            uploaded: c.total || 0,
-            shopped: c.shopped || 0,
-            unique:
-              c.shopperUnique.filter((obj) => obj.shopperFirstName !== '')
-                .length || 0,
-            available: c.available || '',
-          });
-        }
+        //deleted tags sometimes return item data
+        sheetFour.addRow({
+          tag: c._id,
+          uploaded: c.total || 0,
+          shopped: c.shopped || 0,
+          unique:
+            c.shopperUnique.filter((obj) => obj.shopperFirstName !== '')
+              .length || 0,
+          available: c.available || '',
+        });
       });
 
       //create link and download excel

--- a/client/src/components/organisms/Dashboard/DonorItems/DonorItems.js
+++ b/client/src/components/organisms/Dashboard/DonorItems/DonorItems.js
@@ -23,6 +23,10 @@ import {
 } from '../../../../services/items';
 import { Button, H2 } from '../../../atoms';
 import { openHiddenTab, reopenTab, tabList } from '../../../../utils/helpers';
+import {
+  sortQuantities,
+  calculateTotalQuantity,
+} from '../../../../utils/batchItemHelpers';
 import { itemCreateschema } from '../../../../utils/validation';
 
 export const DonorItems = () => {
@@ -152,7 +156,9 @@ export const DonorItems = () => {
       }
       let res = {};
       if (values.batchId) {
-        res = await updateBatchItem(record._id, values, token);
+        const sortedValues = sortQuantities(values);
+        sortedValues.quantity = calculateTotalQuantity(sortedValues);
+        res = await updateBatchItem(record._id, sortedValues, token);
       } else {
         res = await updateItem(record._id, values, token);
       }

--- a/client/src/pages/Item/AddBatchItemToBasket.js
+++ b/client/src/pages/Item/AddBatchItemToBasket.js
@@ -103,15 +103,23 @@ const AddBatchItemToBasketButton = ({
 
     // shopping limit reached
     if (availableQuantity === 0) {
-      const shoppingLimitMessage =
-        item.category === 'children'
-          ? `weekly shopping limit for children's items`
-          : `weekly shopping limit`;
-      confirm({
-        className: 'modalStyle',
-        title: `Shopping Limit Reached!`,
-        content: `You have reached your ${shoppingLimitMessage}. Please check your current orders on your account profile or update your profile info!`,
-      });
+      if (basketItemsCount !== 0) {
+        const shoppingLimitMessage =
+          item.category === 'children'
+            ? `weekly shopping limit for children's items`
+            : `weekly shopping limit`;
+        confirm({
+          className: 'modalStyle',
+          title: `Shopping Limit Reached!`,
+          content: `You have reached your ${shoppingLimitMessage}. Please check your current orders on your account profile or update your profile info!`,
+        });
+      } else if (basketItemsCount === 0) {
+        confirm({
+          className: 'modalStyle',
+          title: `Basket Full`,
+          content: `Please proceed to checkout or remove some items from your basket if you wish to add others.`,
+        });
+      }
       return;
     }
 

--- a/client/src/utils/batchItemHelpers.js
+++ b/client/src/utils/batchItemHelpers.js
@@ -5,6 +5,8 @@ import {
   updateBatchItem,
 } from '../services/items';
 
+import { shoeSizeOptions, clothingSizeOptions } from './constants';
+
 // updates multiple batch items with changes to different sizes per each batch-item
 // example scenario: when resetting the whole basket, we need to clear all items (which may have multiple batch-items)
 // note: it takes a map of batch-items as param
@@ -25,6 +27,7 @@ const bulkUpdateBatchItemQuantity = async (updateDataMap, token) => {
       // Exclude _id from batchItem (eslint complains that '_id' is not used).
       // eslint-disable-next-line
       const { _id, ...batchItemWithoutId } = batchItem;
+      batchItemWithoutId.quantity = calculateTotalQuantity(batchItemWithoutId);
       await updateBatchItem(
         batchItemWithoutId.templateItem,
         batchItemWithoutId,
@@ -77,6 +80,9 @@ const updateBatchItemQuantity = async (
         ...batchItemWithoutId,
         [sizeType]: updatedSizes,
       };
+      updatedBatchItemDetails.quantity = calculateTotalQuantity(
+        updatedBatchItemDetails
+      );
       const response = await updateBatchItem(
         batchItem.templateItem,
         updatedBatchItemDetails,
@@ -142,8 +148,36 @@ const resetBasketItems = async (basket, token) => {
   }
 };
 
+const sortQuantities = (formValues) => {
+  const fieldName =
+    formValues.shoeSizes.length > 0 ? 'shoeSizes' : 'clothingSizes';
+  const sizeOrder =
+    formValues.shoeSizes.length > 0 ? shoeSizeOptions : clothingSizeOptions;
+  const quantities = formValues[fieldName];
+  const keyValueArray = Object.entries(quantities);
+  keyValueArray.sort(
+    (a, b) => sizeOrder.indexOf(a[0]) - sizeOrder.indexOf(b[0])
+  );
+  const sortedQuantities = Object.fromEntries(keyValueArray);
+  return { ...formValues, [fieldName]: sortedQuantities };
+};
+
+const calculateTotalQuantity = (values) => {
+  const fieldName = values.shoeSizes.length > 0 ? 'shoeSizes' : 'clothingSizes';
+  let totalQuantity = 0;
+
+  const sizes = values[fieldName];
+  Object.values(sizes).forEach((quantity) => {
+    totalQuantity += quantity;
+  });
+
+  return totalQuantity;
+};
+
 export {
   resetBasketItems,
   updateBatchItemQuantity,
   bulkUpdateBatchItemQuantity,
+  sortQuantities,
+  calculateTotalQuantity,
 };

--- a/client/src/utils/batchItemHelpers.js
+++ b/client/src/utils/batchItemHelpers.js
@@ -150,9 +150,13 @@ const resetBasketItems = async (basket, token) => {
 
 const sortQuantities = (formValues) => {
   const fieldName =
-    formValues.shoeSizes.length > 0 ? 'shoeSizes' : 'clothingSizes';
+    Object.keys(formValues.shoeSizes).length > 0
+      ? 'shoeSizes'
+      : 'clothingSizes';
   const sizeOrder =
-    formValues.shoeSizes.length > 0 ? shoeSizeOptions : clothingSizeOptions;
+    Object.keys(formValues.shoeSizes).length > 0
+      ? shoeSizeOptions
+      : clothingSizeOptions;
   const quantities = formValues[fieldName];
   const keyValueArray = Object.entries(quantities);
   keyValueArray.sort(
@@ -163,7 +167,8 @@ const sortQuantities = (formValues) => {
 };
 
 const calculateTotalQuantity = (values) => {
-  const fieldName = values.shoeSizes.length > 0 ? 'shoeSizes' : 'clothingSizes';
+  const fieldName =
+    Object.keys(values.shoeSizes).length > 0 ? 'shoeSizes' : 'clothingSizes';
   let totalQuantity = 0;
 
   const sizes = values[fieldName];

--- a/server/models/BatchItem.js
+++ b/server/models/BatchItem.js
@@ -16,6 +16,14 @@ const batchItemSchema = new Schema({
     of: Number,
     default: new Map(),
   },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+  quantity: {
+    type: Number,
+    default: 0,
+  },
 });
 
 const BatchItem = mongoose.model('BatchItem', batchItemSchema);

--- a/server/services/items.js
+++ b/server/services/items.js
@@ -68,7 +68,7 @@ const convertKeys = (input) => {
 };
 
 const createBatchItem = async (data) => {
-  let { clothingSizes, shoeSizes, ...restOfData } = data;
+  let { clothingSizes, shoeSizes, quantity, ...restOfData } = data;
   // Mongoose maps complain about keys with '.' (dots) in them. Therefore, errors when certain sizes (e.g. 2.5) get passed in.
   if (clothingSizes) {
     clothingSizes = convertKeys(clothingSizes);
@@ -81,6 +81,7 @@ const createBatchItem = async (data) => {
     const batchItem = await BatchItem.create({
       clothingSizes: clothingSizes,
       shoeSizes: shoeSizes,
+      quantity: quantity,
     });
     const batchId = batchItem.id;
 
@@ -215,11 +216,13 @@ const updateBatchItem = async (id, updateData) => {
   // I get rid of it here because the updateItem() method takes id as a param and it shouldn't be inside the data param.
   // eslint was complaining because templateItem is otherwise.
   // eslint-disable-next-line no-unused-vars
-  const { clothingSizes, shoeSizes, templateItem, ...restOfData } = updateData;
+  const { clothingSizes, shoeSizes, templateItem, quantity, ...restOfData } =
+    updateData;
 
   // Mongoose maps complain about keys with '.' (dots) in them. Therefore, errors when certain sizes (e.g. 2.5) get passed in.
   batchItem.clothingSizes = clothingSizes ? convertKeys(clothingSizes) : {};
   batchItem.shoeSizes = shoeSizes ? convertKeys(shoeSizes) : {};
+  batchItem.quantity = quantity ? quantity : 0;
   await batchItem.save();
   // Extract sizes without quantities to create a template item with
   const clothingSize = clothingSizes ? Object.keys(clothingSizes) : [];


### PR DESCRIPTION
Issue #42 

I was slightly apprehensive whilst making these changes as it felt "hacky", but given the time constraints and the somewhat dead-end position I found myself in (learning experience from all directions), I am confident after thorough testing with all kinds of data, that the reporting and statistics now correctly incorporates the batchItem data. 

The main idea is that I've added to the batchItem model two extra properties:
- `createdAt`
- `quantity` (which gets calculated upon creation of the batchItem)

Using these two extra properties I basically aggregate the `quantity` and sum them up accordingly to the item counts.
The reason there are so many different `pipelines` for the `aggregateBatchItemGroupData`, is because the method for how to count the sums were a bit different depending on the groupType, e.g. for category & subcategory, it was suffice to just add the `quantity` values, but for the clothingSizes & shoeSizes; I had to go into the size properties themselves and sum up all the sizes across the batchItems.

**Note**: if we eventually decide another way of handling bulk-items, or even to invert the logic of creating all the items upon creation of the bulk-item, we can then revert back to the old code for statistics & reporting.  