### PR TITLE
fix report not showing zeros for available

### DIFF
--- a/client/src/components/molecules/Report/Report.js
+++ b/client/src/components/molecules/Report/Report.js
@@ -171,7 +171,7 @@ export const Report = () => {
           unique:
             c.shopperUnique.filter((obj) => obj.shopperFirstName !== '')
               .length || 0,
-          available: c.available || '',
+          available: c.available || 0,
         });
       });
 
@@ -198,7 +198,7 @@ export const Report = () => {
           unique:
             c.shopperUnique.filter((obj) => obj.shopperFirstName !== '')
               .length || 0,
-          available: c.available || '',
+          available: c.available || 0,
         });
       });
 
@@ -212,7 +212,7 @@ export const Report = () => {
           unique:
             c.shopperUnique.filter((obj) => obj.shopperFirstName !== '')
               .length || 0,
-          available: c.available || '',
+          available: c.available || 0,
         });
       });
 
@@ -227,7 +227,7 @@ export const Report = () => {
           unique:
             c.shopperUnique.filter((obj) => obj.shopperFirstName !== '')
               .length || 0,
-          available: c.available || '',
+          available: c.available || 0,
         });
       });
 
@@ -242,7 +242,7 @@ export const Report = () => {
           unique:
             c.shopperUnique.filter((obj) => obj.shopperFirstName !== '')
               .length || 0,
-          available: c.available || '',
+          available: c.available || 0,
         });
       });
 


### PR DESCRIPTION
#42  
Finishing touches, but the "available" column was missing zero values, instead it had an empty string. 