### PR TITLE
Added conditional size rendering to order view

### DIFF
--- a/client/src/components/molecules/ItemCardLong/ItemCardLong.js
+++ b/client/src/components/molecules/ItemCardLong/ItemCardLong.js
@@ -125,8 +125,12 @@ export const ItemCardLong = ({ item, actionText, action, type, allTags }) => {
         description={
           <>
             {trunc(item.description)}
-            <br />
-            size {displaySizes.join(', ')}
+            {displaySizes.length > 0 && (
+              <>
+                <br />
+                size {displaySizes.join(', ')}
+              </>
+            )}
           </>
         }
         onClick={() => history.push(`/item/${item._id}`)}


### PR DESCRIPTION
Some items e.g. 'other' or 'accessories' may not have a size.