### PR TITLE
Task-Scheduler for lost-batch-items

### DIFF
--- a/server/services/items.js
+++ b/server/services/items.js
@@ -295,12 +295,7 @@ const getLostItems = async () => {
     inBasket: true,
   };
   try {
-    var items = await Item.find(conditions)
-      .sort({ shopperId: -1 })
-      .populate('shopperId')
-      .exec();
-
-    console.log('items: ', items);
+    var items = await Item.find(conditions).exec();
     return items;
   } catch (error) {
     console.error(`Error in getting specific items: ${error}`);
@@ -814,4 +809,5 @@ module.exports = {
   createBatchItem,
   getBatchItem,
   updateBatchItem,
+  getLostItems,
 };

--- a/server/tasks/index.js
+++ b/server/tasks/index.js
@@ -1,3 +1,4 @@
 exports.archive_inactive_message_threads = require('./archiveInactiveThreads');
 exports.example_task_runner_module = require('./exampleTaskModule');
 exports.send_order_status_reminders = require('./sendOrderStatusReminders');
+exports.process_lost_items = require('./processLostItems');

--- a/server/tasks/processLostBatchItems.js
+++ b/server/tasks/processLostBatchItems.js
@@ -1,0 +1,34 @@
+const { getLostItems, getBatchItem, deleteItem } = require('../services/items');
+
+module.exports = async (logger) => {
+  try {
+    const lostItems = await getLostItems();
+
+    /*
+     * For each lost item, find the batch item and increment the count of the
+     * lost item's size. Then delete the lost item.
+     */
+    for (const item of lostItems) {
+      const batchItem = await getBatchItem(item.batchId);
+      const size =
+        item.shoeSize.length > 0 ? item.shoeSize[0] : item.clothingSize[0];
+
+      if (item.shoeSize.length > 0) {
+        batchItem.shoeSizes[size] = (batchItem.shoeSizes[size] || 0) + 1;
+      } else {
+        batchItem.clothingSizes[size] =
+          (batchItem.clothingSizes[size] || 0) + 1;
+      }
+
+      // Increment the quantity property of the batchItem by 1
+      batchItem.quantity = (batchItem.quantity || 0) + 1;
+
+      await batchItem.save();
+      await deleteItem(item._id);
+    }
+
+    logger.info(`Processed ${lostItems.length} lost items.`);
+  } catch (error) {
+    logger.error(`Error processing lost items: ${error}`);
+  }
+};

--- a/server/tasks/processLostBatchItems.js
+++ b/server/tasks/processLostBatchItems.js
@@ -4,31 +4,48 @@ module.exports = async (logger) => {
   try {
     const lostItems = await getLostItems();
 
-    /*
-     * For each lost item, find the batch item and increment the count of the
-     * lost item's size. Then delete the lost item.
-     */
-    for (const item of lostItems) {
-      const batchItem = await getBatchItem(item.batchId);
-      const size =
-        item.shoeSize.length > 0 ? item.shoeSize[0] : item.clothingSize[0];
-
-      if (item.shoeSize.length > 0) {
-        batchItem.shoeSizes[size] = (batchItem.shoeSizes[size] || 0) + 1;
-      } else {
-        batchItem.clothingSizes[size] =
-          (batchItem.clothingSizes[size] || 0) + 1;
+    // Create a map of batchId to lostItems (given many items will be from the same batch, it's more efficient to process them together)
+    const batchIdToLostItems = lostItems.reduce((map, item) => {
+      if (!map[item.batchId]) {
+        map[item.batchId] = [];
       }
+      map[item.batchId].push(item);
+      return map;
+    }, {});
 
-      // Increment the quantity property of the batchItem by 1
-      batchItem.quantity = (batchItem.quantity || 0) + 1;
+    // For each unique batchId, fetch the batchItem once, update it, and then save it
+    for (const batchId in batchIdToLostItems) {
+      const batchItemResponse = await getBatchItem(batchId);
+      if (!batchItemResponse || !batchItemResponse.batchItem) {
+        console.error(`No batch item found for id: ${batchId}`);
+        continue;
+      }
+      const batchItem = batchItemResponse.batchItem;
+      const items = batchIdToLostItems[batchId];
 
+      for (const item of items) {
+        const size =
+          item.shoeSize.length > 0 ? item.shoeSize[0] : item.clothingSize[0];
+
+        if (item.shoeSize.length > 0) {
+          const currentSizeCount = batchItem.shoeSizes.get(size) || 0;
+          batchItem.shoeSizes.set(size, currentSizeCount + 1);
+        } else {
+          const currentSizeCount = batchItem.clothingSizes.get(size) || 0;
+          batchItem.clothingSizes.set(size, currentSizeCount + 1);
+        }
+
+        // Increment the quantity property of the batchItem by 1
+        batchItem.quantity = (batchItem.quantity || 0) + 1;
+
+        await deleteItem(item._id);
+      }
       await batchItem.save();
-      await deleteItem(item._id);
     }
 
     logger.info(`Processed ${lostItems.length} lost items.`);
   } catch (error) {
+    console.error(error);
     logger.error(`Error processing lost items: ${error}`);
   }
 };

--- a/server/tasks/processLostBatchItems.js
+++ b/server/tasks/processLostBatchItems.js
@@ -45,7 +45,6 @@ module.exports = async (logger) => {
 
     logger.info(`Processed ${lostItems.length} lost items.`);
   } catch (error) {
-    console.error(error);
     logger.error(`Error processing lost items: ${error}`);
   }
 };


### PR DESCRIPTION
#42 

Whenever a shopper adds a batch-item to their basket and refreshes their webpage, that item gets rendered lost from the perspective of the code since the state is not persisted and there is no way for the shopper to get it back at the moment.

Until we address the state-persistence issue, this task scheduler - maybe run once every 12 hours or 24 hours - will:

- fetch all the lost-batch-items
- update their respective batchItem size & quantity
- delete the lost-item

Tested on dev environment by simply calling the inner logic manually and it seems to be working - curious to get it setup with a task scheduler. 