### PR TITLE
134 item tagging

### DIFF
--- a/client/src/components/molecules/EditForm/DonorMiniEditForm.js
+++ b/client/src/components/molecules/EditForm/DonorMiniEditForm.js
@@ -42,6 +42,16 @@ export const DonorMiniEditForm = ({ editingKey, recordId, approvalAction }) => {
 
       <div>
         <StyledCheckbox
+          name="canAddItemTags"
+          disabled={editingKey !== recordId}
+        >
+          User can tag items
+        </StyledCheckbox>
+        <StyledError name="canAddItemTags" component="div" />
+      </div>
+
+      <div>
+        <StyledCheckbox
           name="canAddItemInBulk"
           disabled={editingKey !== recordId}
         >

--- a/client/src/components/molecules/EditForm/EditForm.styles.js
+++ b/client/src/components/molecules/EditForm/EditForm.styles.js
@@ -54,6 +54,11 @@ const StyledSelect = styled(Select)`
   }
 `;
 
+const StyledSelectTags = styled(StyledSelect)`
+  font-size: 12px;
+  margin-bottom: 16px;
+`;
+
 const StyledSubmitButton = styled(SubmitButton)`
   width: 150px;
   float: right;
@@ -387,6 +392,7 @@ export {
   StyledForm,
   StyledRadio,
   StyledSelect,
+  StyledSelectTags,
   StyledError,
   InfoNote,
   StyledCheckboxGroup,

--- a/client/src/components/molecules/EditForm/ItemCreateForm.js
+++ b/client/src/components/molecules/EditForm/ItemCreateForm.js
@@ -1,5 +1,6 @@
 import React, { useContext, useState } from 'react';
 import { AppContext } from '../../../context/app-context';
+import { AccountContext } from '../../../context/account-context';
 import { Form } from 'formik-antd';
 import { Formik } from 'formik';
 import { itemCreateschema } from '../../../utils/validation';
@@ -18,6 +19,7 @@ import {
   StyledLabel,
   StyledCheckboxGroup,
   StyledSwitch,
+  StyledSelectTags,
 } from './EditForm.styles';
 import { Images } from '../Images';
 import { CategoryFields } from './CategoryFields';
@@ -29,6 +31,7 @@ import {
 
 export const ItemCreateForm = (data) => {
   const { token, user } = useContext(AppContext);
+  const { allTags } = useContext(AccountContext);
   const [uploadedImages, setUploadedImages] = useState([]);
   const [showBatchOptions, setShowBatchOptions] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState('');
@@ -113,6 +116,17 @@ export const ItemCreateForm = (data) => {
             <StyledInput name="brand" />
           </StyledLabel>
           <StyledError name="brand" component="div" />
+
+          <StyledLabel>
+            Tags
+            <StyledSelectTags mode="tags" name="tags">
+              {(allTags || []).map((tag) => (
+                <StyledSelectTags.Option key={tag.name} value={tag._id}>
+                  {tag.name}
+                </StyledSelectTags.Option>
+              ))}
+            </StyledSelectTags>
+          </StyledLabel>
 
           {showBatchOptions ? (
             <RenderBatchOptions

--- a/client/src/components/molecules/EditForm/ItemCreateForm.js
+++ b/client/src/components/molecules/EditForm/ItemCreateForm.js
@@ -117,16 +117,18 @@ export const ItemCreateForm = (data) => {
           </StyledLabel>
           <StyledError name="brand" component="div" />
 
-          <StyledLabel>
-            Tags
-            <StyledSelectTags mode="tags" name="tags">
-              {(allTags || []).map((tag) => (
-                <StyledSelectTags.Option key={tag.name} value={tag._id}>
-                  {tag.name}
-                </StyledSelectTags.Option>
-              ))}
-            </StyledSelectTags>
-          </StyledLabel>
+          {user.trustedDonor && user.canAddItemTags ? (
+            <StyledLabel>
+              Tags
+              <StyledSelectTags mode="tags" name="tags">
+                {(allTags || []).map((tag) => (
+                  <StyledSelectTags.Option key={tag.name} value={tag._id}>
+                    {tag.name}
+                  </StyledSelectTags.Option>
+                ))}
+              </StyledSelectTags>
+            </StyledLabel>
+          ) : null}
 
           {showBatchOptions ? (
             <RenderBatchOptions

--- a/client/src/components/molecules/EditForm/ItemMiniEditForm.js
+++ b/client/src/components/molecules/EditForm/ItemMiniEditForm.js
@@ -1,7 +1,8 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { AccountContext } from '../../../context/account-context';
 import { Form } from 'formik-antd';
 import { useFormikContext } from 'formik';
+import { AppContext } from '../../../context/app-context';
+import { AccountContext } from '../../../context/account-context';
 import {
   StyledSubmitButton,
   StyledInput,
@@ -27,6 +28,7 @@ export const ItemMiniEditForm = ({
   photos,
   handleImageUpdate,
 }) => {
+  const { user } = useContext(AppContext);
   const { allTags } = useContext(AccountContext);
 
   const [uploadedImages, setUploadedImages] = useState(
@@ -105,20 +107,22 @@ export const ItemMiniEditForm = ({
       </StyledLabel>
       <StyledError name="brand" component="div" />
 
-      <StyledLabel>
-        Tags
-        <StyledSelectTags
-          mode="tags"
-          name="tags"
-          disabled={editingKey !== recordId}
-        >
-          {(allTags || []).map((tag) => (
-            <StyledSelectTags.Option key={tag.name} value={tag._id}>
-              {tag.name}
-            </StyledSelectTags.Option>
-          ))}
-        </StyledSelectTags>
-      </StyledLabel>
+      {user.trustedDonor && user.canAddItemTags ? (
+        <StyledLabel>
+          Tags
+          <StyledSelectTags
+            mode="tags"
+            name="tags"
+            disabled={editingKey !== recordId}
+          >
+            {(allTags || []).map((tag) => (
+              <StyledSelectTags.Option key={tag.name} value={tag._id}>
+                {tag.name}
+              </StyledSelectTags.Option>
+            ))}
+          </StyledSelectTags>
+        </StyledLabel>
+      ) : null}
 
       {item?.batchId ? (
         <RenderBatchOptions

--- a/client/src/components/molecules/EditForm/ItemMiniEditForm.js
+++ b/client/src/components/molecules/EditForm/ItemMiniEditForm.js
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
+import { AccountContext } from '../../../context/account-context';
 import { Form } from 'formik-antd';
 import { useFormikContext } from 'formik';
 import {
@@ -7,6 +8,7 @@ import {
   StyledLabel,
   StyledError,
   StyledCheckboxGroup,
+  StyledSelectTags,
 } from './EditForm.styles';
 import RenderBatchOptions from './RenderBatchOptions';
 import {
@@ -25,6 +27,8 @@ export const ItemMiniEditForm = ({
   photos,
   handleImageUpdate,
 }) => {
+  const { allTags } = useContext(AccountContext);
+
   const [uploadedImages, setUploadedImages] = useState(
     photos.sort((a, b) => b.front - a.front)
   );
@@ -100,6 +104,21 @@ export const ItemMiniEditForm = ({
         <StyledInput name="brand" disabled={editingKey !== recordId} />
       </StyledLabel>
       <StyledError name="brand" component="div" />
+
+      <StyledLabel>
+        Tags
+        <StyledSelectTags
+          mode="tags"
+          name="tags"
+          disabled={editingKey !== recordId}
+        >
+          {(allTags || []).map((tag) => (
+            <StyledSelectTags.Option key={tag.name} value={tag._id}>
+              {tag.name}
+            </StyledSelectTags.Option>
+          ))}
+        </StyledSelectTags>
+      </StyledLabel>
 
       {item?.batchId ? (
         <RenderBatchOptions

--- a/server/controllers/authentication.js
+++ b/server/controllers/authentication.js
@@ -40,6 +40,7 @@ const setUserDetails = (user) => {
 
   if (user.kind === 'donor') {
     UserDetails.trustedDonor = user.trustedDonor || false;
+    UserDetails.canAddItemTags = user.canAddItemTags || false;
     UserDetails.canAddItemInBulk = user.canAddItemInBulk || false;
     UserDetails.canViewShopperAddress = user.canViewShopperAddress || false;
   }

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -93,6 +93,10 @@ const Donor = User.discriminator(
         type: Boolean,
         default: false,
       },
+      canTagItems: {
+        type: Boolean,
+        default: false,
+      },
       canViewShopperAddress: {
         type: Boolean,
         default: false,

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -93,7 +93,7 @@ const Donor = User.discriminator(
         type: Boolean,
         default: false,
       },
-      canTagItems: {
+      canAddItemTags: {
         type: Boolean,
         default: false,
       },


### PR DESCRIPTION
Approved & permitted donor can now set tags on items either during creation or editing...
Admins can permit donors to perform item tagging with the new `caAddItemTags` flag