### PR TITLE
hide batchItems from shop when their quantity is 0

### DIFF
--- a/server/models/Item.js
+++ b/server/models/Item.js
@@ -48,6 +48,7 @@ const itemSchema = new Schema(
         'received-by-gyb',
         'shipped-to-shopper',
         'received',
+        'empty', // used for the template item of a batch-item to indicate that the batch-item is empty
       ],
       // in-shop then shopped when a shopper selects it. shipped-to-gyb and received-by-gyb only used if shopper is sending via gyb
       default: 'in-shop',

--- a/server/services/items.js
+++ b/server/services/items.js
@@ -323,27 +323,35 @@ const getDonorItems = async (userId, itemStatus) => {
   try {
     if (itemStatus !== '') {
       conditions = {
-        /* 
-          Extra condition to exclude "lost-batch-items",
-          which happen when a shopper adds a batch-item to their basket and then refreshes the page.
-          There is a seperate scheduled-task which cleans up these lost items, 
-          but here we don't want to show them to the donor in the first place.
-        */
-        $nor: [
+        $and: [
           {
-            batchId: { $ne: null },
-            isTemplateBatchItem: false,
-            status: { $eq: 'in-shop' },
+            /* 
+              Extra condition to exclude "lost-batch-items",
+              which happen when a shopper adds a batch-item to their basket and then refreshes the page.
+              There is a seperate scheduled-task which cleans up these lost items, 
+              but here we don't want to show them to the donor in the first place.
+            */
+            $nor: [
+              {
+                batchId: { $ne: null },
+                isTemplateBatchItem: false,
+                status: { $eq: 'in-shop' },
+              },
+            ],
           },
-        ],
-        $or: [
-          { approvedStatus: 'approved' },
-          { approvedStatus: 'in-progress' },
-        ],
-        donorId: userId,
-        $or: [
-          { status: itemStatus },
-          { status: itemStatus === 'received' ? 'empty' : itemStatus }, // when templateItem is empty, it can still be viewed in the "past items" for the donor
+          {
+            $or: [
+              { approvedStatus: 'approved' },
+              { approvedStatus: 'in-progress' },
+            ],
+          },
+          { donorId: userId },
+          {
+            $or: [
+              { status: itemStatus },
+              { status: itemStatus === 'received' ? 'empty' : itemStatus }, // when templateItem is empty, it can still be viewed in the "past items" for the donor
+            ],
+          },
         ],
       };
     } else {

--- a/server/services/items.js
+++ b/server/services/items.js
@@ -223,16 +223,28 @@ const updateBatchItem = async (id, updateData) => {
   batchItem.clothingSizes = clothingSizes ? convertKeys(clothingSizes) : {};
   batchItem.shoeSizes = shoeSizes ? convertKeys(shoeSizes) : {};
   batchItem.quantity = quantity ? quantity : 0;
+
   await batchItem.save();
   // Extract sizes without quantities to create a template item with
   const clothingSize = clothingSizes ? Object.keys(clothingSizes) : [];
   const shoeSize = shoeSizes ? Object.keys(shoeSizes) : [];
-  // Create a new data object for updateItem()
+
+  // If the quantity is zero, we want to remove the templateItem from the shop
+  let status;
+  if (batchItem.quantity === 0) {
+    status = 'empty';
+  } else if (batchItem.quantity > 0 && tempItem.status === 'empty') {
+    // if the batchItem is then edited again and the quantity is greater than 0, we want to bring the item back into shop
+    status = 'in-shop';
+  }
+  // Create a new data object for updateItem() with the new status
   const newItemData = {
     ...restOfData,
     clothingSize,
     shoeSize,
+    status,
   };
+
   const updatedItemData = await updateItem(id, newItemData);
   const updatedItem = updatedItemData.item;
 
@@ -329,7 +341,10 @@ const getDonorItems = async (userId, itemStatus) => {
           { approvedStatus: 'in-progress' },
         ],
         donorId: userId,
-        status: itemStatus,
+        $or: [
+          { status: itemStatus },
+          { status: itemStatus === 'received' ? 'empty' : itemStatus }, // when templateItem is empty, it can still be viewed in the "past items" for the donor
+        ],
       };
     } else {
       conditions = {


### PR DESCRIPTION
Whenever a batchItem has no more items, the status is now changed to `empty` on its corresponding templateItem, which subsequently gets removed from the available shop items.

The batchItem can be viewed by the donor in their "past items" and if they wish to edit it again, to add quantity, it will come back in the shop accordingly. 