### PR TITLE
adding a filter to account notifications to exclude gyb-donor items

### DIFF
--- a/server/services/items.js
+++ b/server/services/items.js
@@ -679,10 +679,19 @@ const getAccountNotificationItems = async (adminUserId) => {
       '_id'
     ).lean();
 
+    // Exclude items created by the GYB admins donor account
+    const excludeDonorId = await User_.Donor.findOne(
+      {
+        email: 'giveyourbest.uk@gmail.com',
+      },
+      '_id'
+    );
+
     const condition = {
       $and: [
         { approvedStatus: 'approved' },
         { sendVia: locationId },
+        { donorId: { $ne: excludeDonorId._id } }, // Exclude the specific donorId
         {
           status: {
             $in: [


### PR DESCRIPTION
Regarding issue #170 

This filter already exists on the 'getShopNotifications' and testing it locally, it seems to work correctly in hiding a given donor's (in this case the GYB_HQ donor) items. 

It seems to not have been applied to the 'Account Notifications', so this is just adding it there too in case some items were spotted there.

If the users are able to produce examples of this not working on Production, I can take another look at it.