### PR TITLE
adding a filter to account notifications to exclude gyb-donor items

### DIFF
--- a/client/src/pages/Basket/Basket.js
+++ b/client/src/pages/Basket/Basket.js
@@ -120,7 +120,10 @@ export const Basket = () => {
 
                 //get donor details
                 getUser(item.donorId, token).then((donor) => {
-                  if (user.deliveryPreference === 'direct') {
+                  if (
+                    user.deliveryPreference === 'direct' &&
+                    donor.trustedDonor === true
+                  ) {
                     //send address directly in email
                     user.deliveryAddress.name = name(user);
 
@@ -130,7 +133,10 @@ export const Basket = () => {
                       [item],
                       user.deliveryAddress
                     );
-                  } else if (user.deliveryPreference === 'via-gyb') {
+                  } else if (
+                    user.deliveryPreference === 'via-gyb' ||
+                    donor.trustedDonor === false
+                  ) {
                     //send email without address - to be sent later with gyb address
 
                     sendAutoEmail('item_shopped_pending_address', donor, [

--- a/server/services/items.js
+++ b/server/services/items.js
@@ -679,10 +679,19 @@ const getAccountNotificationItems = async (adminUserId) => {
       '_id'
     ).lean();
 
+    // Exclude items created by the GYB admins donor account
+    const excludeDonorId = await User_.Donor.findOne(
+      {
+        email: 'giveyourbest.uk@gmail.com',
+      },
+      '_id'
+    );
+
     const condition = {
       $and: [
         { approvedStatus: 'approved' },
         { sendVia: locationId },
+        { donorId: { $ne: excludeDonorId._id } }, // Exclude the specific donorId
         {
           status: {
             $in: [

--- a/server/services/items.js
+++ b/server/services/items.js
@@ -419,7 +419,7 @@ const getDonorItems = async (userId, itemStatus) => {
             };
           }
 
-          if (deliveryPreference === 'direct') {
+          if (donor.canViewShopperAddress || deliveryPreference === 'direct') {
             return {
               _id,
               deliveryAddress,


### PR DESCRIPTION
Regarding issue https://github.com/Give-Your-Best/webshop/issues/170

This filter already exists on the 'getShopNotifications' and testing it locally, it seems to work correctly in hiding a given donor's (in this case the GYB_HQ donor) items.

It seems to not have been applied to the 'Account Notifications', so this is just adding it there too in case some items were spotted there.

If the users are able to produce examples of this not working on Production, I can take another look at it.