### PR TITLE
whenever address is not present, hide mark-as-sent button

### DIFF
--- a/client/src/components/molecules/DonorOrdersList/DonorOrdersList.js
+++ b/client/src/components/molecules/DonorOrdersList/DonorOrdersList.js
@@ -29,8 +29,13 @@ export const DonorOrdersList = () => {
   const { allTags } = useContext(AccountContext);
   const [itemsToSend, setItemsToSend] = useState([]);
   const [itemsAwaitingReceived, setItemsAwaitingReceived] = useState([]);
+  const [isAddressVisible, setIsAddressVisible] = useState(false);
   const mountedRef = useRef(true);
   const { confirm } = Modal;
+
+  const handleAddressVisibilityChange = (isVisible) => {
+    setIsAddressVisible(isVisible);
+  };
 
   const markAsSent = (itemsList) => {
     confirm({
@@ -140,12 +145,15 @@ export const DonorOrdersList = () => {
                                 actionText={''}
                                 action={null}
                                 allTags={allTags}
+                                onAddressVisibilityChange={
+                                  handleAddressVisibilityChange
+                                }
                               />
                             </div>
                           );
                         })
                       : ''}
-                    {item.items && item.items.length && (
+                    {item.items && item.items.length && isAddressVisible && (
                       <Button
                         primary
                         right

--- a/client/src/components/molecules/ItemCardLong/ItemCardLong.js
+++ b/client/src/components/molecules/ItemCardLong/ItemCardLong.js
@@ -24,7 +24,14 @@ import {
 
 const { Meta } = AntCard;
 
-export const ItemCardLong = ({ item, actionText, action, type, allTags }) => {
+export const ItemCardLong = ({
+  item,
+  actionText,
+  action,
+  type,
+  allTags,
+  onAddressVisibilityChange,
+}) => {
   const { token, user } = useContext(AppContext);
   let history = useHistory();
   const [deliveryAddress, setDeliveryAddress] = useState({});
@@ -102,6 +109,7 @@ export const ItemCardLong = ({ item, actionText, action, type, allTags }) => {
       user.canViewShopperAddress &&
       user.trustedDonor
     ) {
+      onAddressVisibilityChange(true);
       shopper.deliveryAddress.name = name(shopper);
       setDeliveryAddress(shopper.deliveryAddress);
     } else if (
@@ -113,6 +121,7 @@ export const ItemCardLong = ({ item, actionText, action, type, allTags }) => {
       item.sendVia
     ) {
       const location = await getLocation(item.sendVia, token);
+      onAddressVisibilityChange(true);
       setFAOShopperName(name(shopper));
       setDeliveryAddress(location[0]);
     } else if (
@@ -122,9 +131,11 @@ export const ItemCardLong = ({ item, actionText, action, type, allTags }) => {
       shopper.deliveryPreference !== 'via-gyb' &&
       shopper.deliveryAddress
     ) {
+      onAddressVisibilityChange(true);
       shopper.deliveryAddress.name = name(shopper);
       setDeliveryAddress(shopper.deliveryAddress);
     } else {
+      onAddressVisibilityChange(false);
       // Else we show the 'address not yet assigned' label.
       setAddressFound(true);
     }


### PR DESCRIPTION
I have found a scenario where the 'mark as sent' button creates a problem.

If a donor account does not have the ability to see the shopper's address i.e. User can view shopper address = false  AND user has not shared the address directly AND the address has not yet been assigned AND for some reason (user error) the donor nonetheless presses the 'Mark as Sent'. This will by-pass sending it to GYB via the admin account, in which case, that item (from the perspective of the code & db) will be sent directly to the user (since the db knows the shopperId's address despite the fact that donor does not know it).

In reality this would mean this:
- Shopper shops an item
- Donor accidentally presses 'mark as sent' before having the item's delivery address assigned to it
- The item is 'sent' to the shopper (from the db perspective) and therefore never gets flagged in the admin notifications (but in reality, the donor never received the address for anything and so potentially creating a missing item?)

I assume this hasn't been a big problem, but thought to add the check whilst I was looking at this particular case anyway.
Now, the 'Mark as Sent' button (for the donors) will only appears if there is a valid address. (See screenshots)

<img width="778" alt="Screenshot 2024-09-20 at 17 43 12" src="https://github.com/user-attachments/assets/e181023c-c857-4026-a05d-ea160987840d">
<img width="786" alt="Screenshot 2024-09-20 at 17 43 17" src="https://github.com/user-attachments/assets/33e26e6e-2c04-4e00-a06f-204720629183">
<img width="787" alt="Screenshot 2024-09-20 at 17 44 14" src="https://github.com/user-attachments/assets/aeb17f21-9e7f-479e-a33b-7e0f23b14c40">
