### PR TITLE
auto assign untrusted donor items to gyb address upon checking out

### DIFF
--- a/client/src/pages/Basket/Basket.js
+++ b/client/src/pages/Basket/Basket.js
@@ -134,15 +134,28 @@ export const Basket = () => {
                       user.deliveryAddress
                     );
                   } else if (
-                    user.deliveryPreference === 'via-gyb' ||
-                    donor.trustedDonor === false
+                    user.deliveryPreference === 'via-gyb' &&
+                    donor.trustedDonor === true
                   ) {
                     //send email without address - to be sent later with gyb address
-
                     sendAutoEmail('item_shopped_pending_address', donor, [
                       item,
                     ]);
                     sendAutoEmail('new_item_to_assign_location');
+                  } else if (donor.trustedDonor === false) {
+                    // When donor is not trusted we want to send the item via GYB regardless of the user's delivery preference
+                    // setting 'sendVia' directly to the GYB location ID means that it will by-passes the need for manual location assingment in the [Shop Notifications].
+                    // Upon checking-out this basket, it will notify the donor that they have an item to dispatch (and the address will be the GYB office).
+
+                    let updateData = {
+                      sendVia: '6539040db9c7d96390fe8f2e', // need to find a better way to get this ID - it's the GYB location ID
+                      'statusUpdateDates.gybAssignedDate': getDate(),
+                    };
+                    updateItem(item._id, updateData, token).then(() => {
+                      sendAutoEmail('item_shopped_auto_send_via_gyb', donor, [
+                        item,
+                      ]);
+                    });
                   }
                 });
                 return true;

--- a/client/src/pages/Basket/Basket.js
+++ b/client/src/pages/Basket/Basket.js
@@ -148,7 +148,7 @@ export const Basket = () => {
                     // Upon checking-out this basket, it will notify the donor that they have an item to dispatch (and the address will be the GYB office).
 
                     let updateData = {
-                      sendVia: '6539040db9c7d96390fe8f2e', // need to find a better way to get this ID - it's the GYB location ID
+                      sendVia: '63da693b03ae730016ca7e16', // need to find a better way to get this ID - it's the GYB location ID
                       'statusUpdateDates.gybAssignedDate': getDate(),
                     };
                     updateItem(item._id, updateData, token).then(() => {

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -695,6 +695,13 @@ export const autoEmails = [
       "/dashboard'>Log In</a>",
   },
   {
+    type: 'item_shopped_auto_send_via_gyb',
+    content:
+      "<p>Hi {{name}}!<p><p>You’ve had an item shopped which will be sent via our Give Your Best office and is waiting for dispatch.</p><a href='" +
+      homeLink +
+      "/dashboard'>Log In</a>",
+  },
+  {
     type: 'new_signup',
     content:
       "<p>Hi Admin!<p><p>There’s been a new sign up! Please log in here to review the application.</p><a href='" +


### PR DESCRIPTION
Issue #172 

This code will auto-assign the item's `sendVia` property to that of GYB office's location_id. 
It will also notify the donor that they need to dispatch an item. 

Seeking thoughts & advice on how to better handle the GYB office's location ID. 

`
let updateData = {
                      sendVia: '6539040db9c7d96390fe8f2e', // need to find a better way to get this ID
                      'statusUpdateDates.gybAssignedDate': getDate(),
};
`

In the Basket view, we don't have a simple way to fetch the location by name (which could be a nice-to-have). Perhaps there's even better ways to handle it.

For now, I'll keep it like this until we / I come up with a better idea as I progress through the other related task.

Tested locally with the following scenarios:

1. TrustedDonor: TRUE && showAddress: FALSE -> No address is shown, admin assigns manually via shop notifications. 
2. TrustedDonor: TRUE && showAddress: TRUE -> Address is shown directly, no need for assignment
3. TrustedDonor: FALSE && showAddress: TRUE -> Auto-assigns GYB's office location and notifies the donor
4. TrustedDonor: FALSE && showAddress: FALSE -> Auto-assigns GYB's office location and notifies the donor 

Email service is setup to only work on PROD, so naturally I'm making an assumption the email works.
