### PR TITLE
172 auto assign untrusted items

### DIFF
--- a/client/src/services/user/evaluateDonorTrust.js
+++ b/client/src/services/user/evaluateDonorTrust.js
@@ -1,0 +1,18 @@
+export const evaluateDonorTrust = async (itemId, token) => {
+  //call api to evaluate donor & update if needed
+  try {
+    const response = await fetch(`/api/users/donor/trust/${itemId}`, {
+      method: 'put',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'x-access-token': token,
+      },
+    });
+    const jsonres = await response.json();
+    return jsonres;
+  } catch (error) {
+    console.error(`Error in evaluateDonorTrust: ${error}`);
+    return error;
+  }
+};

--- a/client/src/services/user/index.js
+++ b/client/src/services/user/index.js
@@ -15,3 +15,4 @@ export { updatePassword } from './updatePassword';
 export { getGYBDummyUser } from './getGYBDummyUser';
 export { listUsers } from './listUsers';
 export { countUsers } from './countUsers';
+export { evaluateDonorTrust } from './evaluateDonorTrust';

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -134,6 +134,29 @@ const updateAdmin = async (req, res) => {
   }
 };
 
+const evaluateDonorTrust = async (req, res) => {
+  const itemId = req.params.id;
+  try {
+    const result = await UserService.evaluateDonorTrust(itemId);
+
+    if (result.updated) {
+      return res.status(200).json({
+        success: true,
+        message: 'Donor trust status evaluated and updated successfully.',
+      });
+    } else {
+      return res.status(200).json({
+        success: true,
+        message: 'Donor trust status evaluated. No update was necessary.',
+      });
+    }
+  } catch (err) {
+    req.bugsnag.notify(err);
+    console.error(`Service error: ${err}`);
+    return res.status(500).send({ message: `Service error: ${err}` });
+  }
+};
+
 module.exports = {
   createUser,
   updateUser,
@@ -141,4 +164,5 @@ module.exports = {
   updateShopper,
   updateAdmin,
   registerUser,
+  evaluateDonorTrust,
 };

--- a/server/routes/api/users.js
+++ b/server/routes/api/users.js
@@ -66,6 +66,9 @@ router.get('/dummyadmin/:name', async (req, res) => {
 // update user endpoint put to api/users/:id
 router.put('/:id', Users.updateUser);
 
+// Evaluate trust status endpoint PUT to api/users/donor/trust/:id
+router.put('/donor/trust/:id', Users.evaluateDonorTrust);
+
 // update user endpoint put to api/users/:id
 router.put('/donor/:id', Users.updateDonor);
 

--- a/server/services/users.js
+++ b/server/services/users.js
@@ -313,8 +313,6 @@ const evaluateDonorTrust = async (itemId) => {
   }
 };
 
-module.exports = { evaluateDonorTrust }; // Export as part of UserService
-
 module.exports = {
   createUser,
   getUser,

--- a/server/services/users.js
+++ b/server/services/users.js
@@ -268,6 +268,53 @@ const getGYBDummyUser = async (name) => {
   }
 };
 
+// Used for auto-trusting donors upon receiving 5 items
+// via the 'Mark received' by an admin in 'Account Notifications'
+const evaluateDonorTrust = async (itemId) => {
+  try {
+    // Fetch the item
+    const item = await Item.findById(itemId);
+    if (!item) throw new Error('Item not found');
+
+    // Fetch the donor associated with the item
+    const donor = await User_.User.findById(item.donorId);
+    if (!donor) throw new Error('Donor not found');
+
+    // If the donor is already trusted, no further action is needed
+    if (donor.trustedDonor) {
+      return { updated: false };
+    }
+
+    // Define the statuses that verify the donor's trust
+    const receivedStatuses = [
+      'received-by-gyb',
+      'shipped-to-shopper',
+      'received',
+    ];
+
+    // Count how many of the donor's items have been received by GYB or are in the verified statuses
+    const receivedByGYBCount = await Item.countDocuments({
+      donorId: donor._id,
+      status: { $in: receivedStatuses },
+    });
+
+    // If the donor has at least 5 items with the verified statuses, mark the donor as trusted
+    // This takes into account the current item being processed as the 5th item, fulfilling the trust criteria
+    if (receivedByGYBCount >= 5) {
+      donor.trustedDonor = true;
+      await donor.save();
+      return { updated: true }; // Donor was updated to trusted
+    }
+
+    return { updated: false }; // Not enough items in verified statuses, no update
+  } catch (error) {
+    console.error('Error in evaluateDonorTrust service:', error);
+    throw error;
+  }
+};
+
+module.exports = { evaluateDonorTrust }; // Export as part of UserService
+
 module.exports = {
   createUser,
   getUser,
@@ -283,4 +330,5 @@ module.exports = {
   updateAdmin,
   getGYBDummyUser,
   getDonations,
+  evaluateDonorTrust,
 };


### PR DESCRIPTION
Issue #172 

This PR addresses the auto-trusting donors upon an admin marking their items as 'received' in the [Account Notifications].

The decision to make the `evaluateDonorTrust` as a backend service was mainly to avoid having to make multiple fetch calls on the frontend:

- get the full item (itemId)
- get the donor user (item.donorId)
- fetch/count all items with donorId (whose status is one in the verified status)
- then make the judgement whether to update or not.

Instead of performing all of the above in the client, I decided to perform these tasks on the backend. 

Thoroughly tested locally in various scenarios.

Feedback is always welcome :) 