### PR TITLE
added tooltip to the mark-as-sent button for user clarity

### DIFF
--- a/client/src/components/molecules/DonorOrdersList/DonorOrdersList.js
+++ b/client/src/components/molecules/DonorOrdersList/DonorOrdersList.js
@@ -1,7 +1,7 @@
 import React, { useContext, useState, useEffect, useRef } from 'react';
 import { AppContext } from '../../../context/app-context';
 import { AccountContext } from '../../../context/account-context';
-import { Modal } from 'antd';
+import { Modal, Tooltip } from 'antd';
 import {
   ListWrapper,
   HiddenStyledTab,
@@ -153,15 +153,27 @@ export const DonorOrdersList = () => {
                           );
                         })
                       : ''}
-                    {item.items && item.items.length && isAddressVisible && (
-                      <Button
-                        primary
-                        right
-                        small
-                        onClick={() => markAsSent(item.items)}
+                    {item.items && item.items.length && (
+                      <Tooltip
+                        placement="topRight"
+                        title={
+                          !isAddressVisible
+                            ? 'This button is enabled only whenever the address has been set on the item. Please click `View delivery address` to check if an address has been set.'
+                            : ''
+                        }
                       >
-                        Mark as Sent
-                      </Button>
+                        <div>
+                          <Button
+                            primary
+                            right
+                            small
+                            disabled={!isAddressVisible}
+                            onClick={() => markAsSent(item.items)}
+                          >
+                            Mark as Sent
+                          </Button>
+                        </div>
+                      </Tooltip>
                     )}
                   </ShopperWrapper>
                 );

--- a/server/services/users.js
+++ b/server/services/users.js
@@ -1,5 +1,6 @@
 const Item = require('../models/Item');
 const User_ = require('../models/User');
+const { sendMail } = require('../services/mail');
 
 const createUser = async (data) => {
   try {
@@ -303,6 +304,15 @@ const evaluateDonorTrust = async (itemId) => {
     if (receivedByGYBCount >= 5) {
       donor.trustedDonor = true;
       await donor.save();
+
+      // Construct the email content
+      const homeLink = 'https://shop.giveyourbest.uk/dashboard';
+      const emailSubject = 'Your Account Has Been Approved';
+      const emailHTML = `<p>Dear ${donor.firstName},</p><p>Great news, your 5 items have been shopped successfully so your account has been approved! You are now able to continue uploading items.</p><p>Thank you for your donations and support.</p><a href='${homeLink}'>Log In</a>`;
+
+      // Send the email
+      await sendMail(emailSubject, emailHTML, donor.email, donor.firstName);
+
       return { updated: true }; // Donor was updated to trusted
     }
 


### PR DESCRIPTION
The `Mark as sent` button was conditionally rendered by the logic within the `View delivery address` button.

A user got confused where the `Mark as sent` button went, given they had already previewed the address on the item, went away to package it up and as they had reloaded the page upon their arrival back, the `Mark as sent` button was gone too (in actuality: it just needed to be triggered again by clicking the `View delivery address`). 

This PR doesn't solve the underlying clunkiness of this issue but simply makes it slightly more user-friendly by always having the `Mark as sent` visible (instead of conditionally rendered), but instead, it now `disables` the button with an added tooltip to give the user the extra instruction i.e. to press the `View delivery address` to trigger the address check.

It would be better for the `Mark as sent` button to handle its own logic for checking whether the item(s) it represents, all have valid delivery addresses assigned, however, this would require a bit of refactoring that I unfortunately don't have the time for - it's not difficult, just requires to carefully ensure that the address is checked when the component loads for each item in the `DonorOrdersList.js` instead of just in the `ItemCardLong.js` (upon clicking the `View delivery address`).

