### PR TITLE
commenting out donor limit constraint

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,9 +19,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/client/src/components/molecules/EditForm/ShopSettingsEditForm.js
+++ b/client/src/components/molecules/EditForm/ShopSettingsEditForm.js
@@ -56,14 +56,21 @@ export const ShopSettingsEditForm = (data) => {
             <StyledError name="shopItemLimit" component="div" />
           </StyledLabel>
 
-          <StyledLabel>
+          {/*
+           * ============================================================
+           *             !! DONOR ITEM UPLOAD CONSTRAINT !!
+           * Commenting out the following code as the team have decided to remove
+           * the item constraint. To resume, please uncomment.
+           * ============================================================
+           */}
+          {/* <StyledLabel>
             Trusted Donor Limit
             <StyledInputNumber
               name="trustedDonorLimit"
               placeholder="Trusted Donor Limit"
             />
             <StyledError name="trustedDonorLimit" component="div" />
-          </StyledLabel>
+          </StyledLabel> */}
 
           <StyledLabel>
             Shop Email{' '}

--- a/client/src/components/molecules/ItemCardLong/ItemCardLong.js
+++ b/client/src/components/molecules/ItemCardLong/ItemCardLong.js
@@ -104,7 +104,6 @@ export const ItemCardLong = ({
       // Special case, if the donor is trusted and approved by admin to view any
       // shopper address regardless of shopper delivery preference then show the
       // address on request...
-      shopper.deliveryPreference === 'via-gyb' &&
       shopper.deliveryAddress &&
       user.canViewShopperAddress &&
       user.trustedDonor
@@ -115,11 +114,17 @@ export const ItemCardLong = ({
       shopper.deliveryAddress.name = name(shopper);
       setDeliveryAddress(shopper.deliveryAddress);
     } else if (
-      // If the donor is not yet trusted the package must be sent via gyb
-      // whether the shopper requests it or not - in this case, or in the case
-      // that the shopper requests via gyb and there is a location assigned,
-      // then provide that address...
-      (!user.trustedDonor || shopper.deliveryPreference === 'via-gyb') &&
+      /*
+       * ============================================================
+       *             !! DONOR ITEM UPLOAD CONSTRAINT !!
+       * Commenting out the following code as the team have decided to remove
+       * the untrusted donor constraint to send items via GYB HQ.
+       * To resume, please add !user.trustedDonor to the if statement.
+       * ============================================================
+       */
+      // In the case that the shopper requests via gyb
+      // and there is a location assigned, then provide that address...
+      shopper.deliveryPreference === 'via-gyb' &&
       item.sendVia
     ) {
       const location = await getLocation(item.sendVia, token);
@@ -129,9 +134,8 @@ export const ItemCardLong = ({
       setFAOShopperName(name(shopper));
       setDeliveryAddress(location[0]);
     } else if (
-      // If the donor is trusted and is allowed to see the shopper address,
+      // If the shopper has allowed disclosure of their address to the donor
       // reveal it here...
-      user.trustedDonor &&
       shopper.deliveryPreference !== 'via-gyb' &&
       shopper.deliveryAddress
     ) {

--- a/client/src/components/organisms/Dashboard/DonorItems/DonorItems.js
+++ b/client/src/components/organisms/Dashboard/DonorItems/DonorItems.js
@@ -1,6 +1,6 @@
 import React, { useContext, useCallback, useState, useEffect } from 'react';
 import { Formik } from 'formik';
-import { Modal, Tooltip } from 'antd';
+import { Modal } from 'antd';
 import { AppContext } from '../../../../context/app-context';
 import {
   ItemsCollapsedList,
@@ -8,7 +8,6 @@ import {
   ItemCreateForm,
 } from '../../../molecules';
 import {
-  StyledAlert,
   StyledTabListHidden,
   StyledTabs,
   StyledTabPanel,
@@ -33,7 +32,7 @@ import { itemCreateschema } from '../../../../utils/validation';
 export const DonorItems = () => {
   const { token, user } = useContext(AppContext);
   const [items, setItems] = useState([]);
-  const [canAddItems, setCanAddItems] = useState(false);
+  // const [canAddItems, setCanAddItems] = useState(false); // DONOR ITEM UPLOAD CONSTRAINT: uncomment to revert back.
   const [pastItems, setPastItems] = useState([]);
   const [errorMessage, setErrorMessage] = useState([]);
   const [editingKey, setEditingKey] = useState([]);
@@ -51,7 +50,8 @@ export const DonorItems = () => {
   }, [token, user]);
 
   const fetchItems = useCallback(async () => {
-    const [shopItems, pastItems, restItems] = await Promise.all([
+    // const [shopItems, pastItems, restItems] = await Promise.all([ // DONOR ITEM UPLOAD CONSTRAINT: uncomment to revert back.
+    const [shopItems, pastItems] = await Promise.all([
       getDonorItems(user.id, 'in-shop'),
       getDonorItems(user.id, 'received'),
       getDonorItems(user.id),
@@ -60,10 +60,19 @@ export const DonorItems = () => {
     setItems(shopItems);
     setPastItems(pastItems);
 
+    /*
+     * ============================================================
+     *             !! DONOR ITEM UPLOAD CONSTRAINT !!
+     * Commenting out the following code as the team have decided to remove
+     * the 5 item constraint. To resume, please uncomment.
+     * ============================================================
+     */
+
     // Donor not yet marked trusted can upload no more than 5 items
-    setCanAddItems(
-      user.trustedDonor || [...shopItems, ...pastItems, ...restItems].length < 5
-    );
+    // setCanAddItems(
+    //   user.trustedDonor ||
+    //     [...shopItems, ...pastItems, ...restItems].length < 5,
+    // );
   }, [user.id, user.trustedDonor]);
 
   useEffect(fetchItems, [user, token, fetchItems]);
@@ -205,7 +214,14 @@ export const DonorItems = () => {
       <StyledTabPanel>
         <H2>My Available Items</H2>
 
-        {user.trustedDonor && (
+        {/*
+         * ============================================================
+         *             !! DONOR ITEM UPLOAD CONSTRAINT !!
+         * Commenting out the following code as the team have decided to remove
+         * the 5 item constraint. To resume, please uncomment.
+         * ============================================================
+         */}
+        {/* {user.trustedDonor && (
           <>
             <StyledAlert
               description={
@@ -215,7 +231,7 @@ export const DonorItems = () => {
             />
             <br />
           </>
-        )}
+        )} */}
         <ItemsCollapsedList
           data={items}
           expandRow={editForm}
@@ -227,7 +243,18 @@ export const DonorItems = () => {
           View Past Items
         </Button>
 
-        {canAddItems ? (
+        <Button primary small onClick={() => openHiddenTab('item')}>
+          Add Item
+        </Button>
+        {/*
+         * ============================================================
+         *             !! DONOR ITEM UPLOAD CONSTRAINT !!
+         * Commenting out the following code as the team have decided to remove
+         * the 5 item constraint. To resume, please uncomment the canAddItems.
+         * ============================================================
+         */}
+
+        {/* {canAddItems ? (
           <Button primary small onClick={() => openHiddenTab('item')}>
             Add Item
           </Button>
@@ -239,7 +266,7 @@ export const DonorItems = () => {
               </Button>
             </div>
           </Tooltip>
-        )}
+        )} */}
       </StyledTabPanel>
       <StyledTabPanel>
         <H2>Add Item</H2>

--- a/client/src/components/organisms/Dashboard/DonorItems/DonorItems.js
+++ b/client/src/components/organisms/Dashboard/DonorItems/DonorItems.js
@@ -73,7 +73,7 @@ export const DonorItems = () => {
     //   user.trustedDonor ||
     //     [...shopItems, ...pastItems, ...restItems].length < 5,
     // );
-  }, [user.id, user.trustedDonor]);
+  }, [user.id]);
 
   useEffect(fetchItems, [user, token, fetchItems]);
 

--- a/server/services/items.js
+++ b/server/services/items.js
@@ -7,20 +7,28 @@ const { cloudinary } = require('../utils/cloudinary');
 const BatchItem = require('../models/BatchItem');
 
 const createItem = async (data, bypassImageUpload = false) => {
-  // Donor not yet marked trusted can upload no more than 5 items
-  const donor = await User_.Donor.findById(data.donorId);
-  if (donor.trustedDonor === false) {
-    const userItemsCount = await Item.countDocuments({
-      donorId: donor.id,
-    });
+  /*
+   * ============================================================
+   *               !! DONOR ITEM UPLOAD CONSTRAINT !!
+   * Commenting out the following code as the team have decided to remove
+   * the 5 item constraint. To resume, please uncomment the code directly below.
+   * ============================================================
+   */
 
-    if (userItemsCount >= 5) {
-      throw new Error('Cannot exceed new donor items limit');
-    }
-  }
+  // Donor not yet marked trusted can upload no more than 5 items
+  // const donor = await User_.Donor.findById(data.donorId);
+
+  // if (donor.trustedDonor === false) {
+  //   const userItemsCount = await Item.countDocuments({
+  //     donorId: donor.id,
+  //   });
+
+  //   if (userItemsCount >= 5) {
+  //     throw new Error('Cannot exceed new donor items limit');
+  //   }
+  // }
 
   if (!bypassImageUpload) {
-    console.log('uploading image');
     var new_photos = [];
     var success = true;
     const promises = data.photos.map((photo) => {
@@ -80,11 +88,19 @@ const convertKeys = (input) => {
 };
 
 const createBatchItem = async (data) => {
+  /*
+   * ============================================================
+   *               !! DONOR ITEM UPLOAD CONSTRAINT !!
+   * Commenting out the following code as the team have decided to remove
+   * the 5 item constraint. To resume, please uncomment the code directly below.
+   * ============================================================
+   */
+
   // Donor not yet marked trusted can upload no more than 5 items
-  const donor = await User_.Donor.findById(data.donorId);
-  if (donor.trustedDonor === false || donor.canAddItemInBulk === false) {
-    throw new Error('Donor cannot add items in bulk');
-  }
+  // const donor = await User_.Donor.findById(data.donorId);
+  // if (donor.trustedDonor === false || donor.canAddItemInBulk === false) {
+  //   throw new Error('Donor cannot add items in bulk');
+  // }
 
   let { clothingSizes, shoeSizes, quantity, ...restOfData } = data;
   // Mongoose maps complain about keys with '.' (dots) in them. Therefore, errors when certain sizes (e.g. 2.5) get passed in.


### PR DESCRIPTION
Request from the GYB team to remove the untrusted donor constraints that were added last year.

The comment reads:

> Hi team, hope you’re all well and enjoying the longer days! We have had a review of the New Donor parcel checking process - thank you so much for setting that up as it was such a necessary measure after the august riots.
We have not had any issues with new donor parcels coming through HQ over the last 6 months, so we’d like to go ahead and remove this extra measure for now, so new donors will behave the same as all donors, without having to send the first 5 parcels via HQ, and with no limit to the amount of items they can upload from the start.
I’m not sure how this was set up, but it would be great to keep it as a feature we’d be able to ‘switch on’ again if needed in the future!
Thank you so much!

Due to a lack of time, making this into a feature that can be toggled is more effort than maybe it's worth it. That is, setting up a frontend and a backend toggle mechanism when in practice, it won't be necessary that often; one assumes. Given an urgent need for it to be put back, a simple 30 minute effort from a dev should solve it, by removing the comments anywhere where it says:

`!! DONOR ITEM UPLOAD CONSTRAINT !!` <--- Search for that in the codebase.