### PR TITLE
added a new report for weekly shoppers in london

### DIFF
--- a/server/tasks/generateHistoricReport.js
+++ b/server/tasks/generateHistoricReport.js
@@ -3,6 +3,7 @@ const {
   generateReport,
   getLatestReportByType,
   generateLatestShoppersReport,
+  generateWeeklyLondonShoppersReport,
 } = require('../services/reports');
 const { sendBulkMail, sendMail } = require('../services/mail');
 const { getAllSettings } = require('../services/settings');
@@ -62,15 +63,12 @@ async function sendHistoricReport(logger) {
 }
 
 // Code for handling the latest shoppers report
-async function sendReportEmail(csvData, logger) {
+async function sendReportEmail(csvData, subject, emailHTML, logger) {
   const settings = await getAllSettings();
   const recipients = settings
     .filter(({ name }) => name === 'reportRecipient')
     .map(({ value }) => value);
 
-  const subject = 'GYB Latest Shoppers Data Available';
-  const emailHTML =
-    '<p>This email is automatically generated on the first day of each month. Attached is a csv file with the latest shoppers data available.</p>';
   const mailResponse = await sendBulkMail(subject, emailHTML, recipients, {
     name: 'latest_shoppers.csv',
     data: csvData,
@@ -106,7 +104,26 @@ async function sendLatestShoppersCsv(logger) {
   try {
     const csvData = await generateLatestShoppersReport();
     if (csvData) {
-      await sendReportEmail(csvData, logger);
+      const subject = 'GYB Latest Shoppers Data Available';
+      const emailHTML =
+        '<p>This email is automatically generated on the first day of each month. Attached is a csv file with the latest shoppers data available.</p>';
+      await sendReportEmail(csvData, subject, emailHTML, logger);
+    } else {
+      await handleReportGenerationFailure(logger);
+    }
+  } catch (error) {
+    logger.error(`Error generating shoppers report: ${error}`);
+  }
+}
+
+async function sendWeeklyLondonShoppers(logger) {
+  try {
+    const csvData = await generateWeeklyLondonShoppersReport();
+    if (csvData) {
+      const subject = 'GYB Weekly London Shoppers Report';
+      const emailHTML =
+        '<p>This email is automatically generated and contains the weekly report of new shoppers with London or Greater London postcodes. Attached is a csv file with the data.</p>';
+      await sendReportEmail(csvData, subject, emailHTML, logger);
     } else {
       await handleReportGenerationFailure(logger);
     }
@@ -117,23 +134,36 @@ async function sendLatestShoppersCsv(logger) {
 
 // Code for orchestrating the reports. This will be exported and used in the scheduler
 async function reportsOrchestrator(logger) {
-  // Get the day of the month
-  const date = moment().date();
+  const today = moment();
+  const dayOfMonth = today.date();
+  const dayOfWeek = today.isoWeekday(); // 1 = Monday, 7 = Sunday
 
-  // This job is triggered on a daily schedule but we only want it to run once
-  // a month at the start of the month...
-  if (date !== 1) {
-    logger.info('Not the first day of the month. Skipping tasks.');
-    return;
+  let taskExecuted = false;
+
+  // Run monthly reports on the first day of the month
+  if (dayOfMonth === 1) {
+    logger.info('First day of the month. Running monthly tasks.');
+    await sendHistoricReport(logger);
+    await sendLatestShoppersCsv(logger);
+    taskExecuted = true;
   }
 
-  logger.info('First day of the month. Running tasks.');
-  await sendHistoricReport(logger);
-  await sendLatestShoppersCsv(logger);
+  // Run weekly reports on the first day of the week (Monday)
+  if (dayOfWeek === 1) {
+    logger.info('First day of the week (Monday). Running weekly tasks.');
+    await sendWeeklyLondonShoppers(logger);
+    taskExecuted = true;
+  }
+
+  // Log if no tasks are executed
+  if (!taskExecuted) {
+    logger.info('No reports to generate today.');
+  }
 }
 
 module.exports = {
   sendHistoricReport,
   sendLatestShoppersCsv,
   reportsOrchestrator,
+  sendWeeklyLondonShoppers,
 };


### PR DESCRIPTION
Added a new report, to run weekly (on Mondays), that generates Names & Emails of shoppers created in the last week who are based in London or Greater London.

Filter query:
- Kind: Shopper
- CreatedAt (In the last 7 days)
- Postcode: London or Greater London (using a long regex)

Output:
-  `FirstName, LastName, Email`